### PR TITLE
Replace loadingPlaceholder with SizedBox.shrink() and update version

### DIFF
--- a/lib/component/smart_image.dart
+++ b/lib/component/smart_image.dart
@@ -200,7 +200,7 @@ class _SmartImageState extends State<SmartImage> {
               newHeight: heightBasedOnDivisor,
               newWidth: widthBasedOnDivisor,
             );
-            return loadingPlaceholder;
+            return SizedBox.shrink();
           },
         ),
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: fae5c4fc1a73b7dee94b6c54e86101e5030a8e42112e61203f464495011a20a1
+      sha256: "7981eb922842c77033026eb4341d5af651562008cdb116bdfa31fc46516b6462"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.1"
+    version: "2.12.2"
   built_collection:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fabric_flutter
 description: Native components and helpers
-version: 2.1.4
+version: 2.1.5
 
 environment:
   sdk: ^3.10.7


### PR DESCRIPTION
This pull request includes a minor update to the Flutter project, primarily addressing the behavior of the image loading placeholder and incrementing the package version.

UI behavior update:

* In `lib/component/smart_image.dart`, replaced the image loading placeholder with `SizedBox.shrink()` to ensure no placeholder is shown while the image loads.

Project versioning:

* Updated the package version in `pubspec.yaml` from `2.1.4` to `2.1.5`.