### PR TITLE
Change phone verification code type and improve Google sign-in handling

### DIFF
--- a/lib/state/state_view_auth.dart
+++ b/lib/state/state_view_auth.dart
@@ -15,11 +15,11 @@ class StateViewAuth extends ChangeNotifier {
   }
 
   /// Phone verification code 123456
-  int? _phoneVerificationCode;
+  String? _phoneVerificationCode;
 
-  int? get phoneVerificationCode => _phoneVerificationCode;
+  String? get phoneVerificationCode => _phoneVerificationCode;
 
-  set phoneVerificationCode(int? value) {
+  set phoneVerificationCode(String? value) {
     _phoneVerificationCode = value;
     notifyListeners();
   }

--- a/lib/view/view_auth_page.dart
+++ b/lib/view/view_auth_page.dart
@@ -340,11 +340,22 @@ class ViewAuthPageState extends State<ViewAuthPage> {
           final GoogleSignInAuthentication googleAuth =
               authenticated.authentication;
           // Access token is obtained via the authorization client for the account.
+          // Prefer the authorization client's access token but fall back to
+          // the authentication object's accessToken. Some platforms may not
+          // return an idToken, so accept either token as long as one is
+          // available. If neither token is available, surface a helpful
+          // message rather than passing nulls into Firebase.
           final clientAuth = await authenticated.authorizationClient
               .authorizationForScopes(googleScopes);
+          final String? accessToken = clientAuth?.accessToken;
+          final String? idToken = googleAuth.idToken;
+          assert(
+            accessToken != null || idToken != null,
+            'At least one of ID token and access token is required',
+          );
           final credential = GoogleAuthProvider.credential(
-            accessToken: clientAuth?.accessToken,
-            idToken: googleAuth.idToken,
+            accessToken: accessToken,
+            idToken: idToken,
           );
           await _auth.signInWithCredential(credential);
         }

--- a/lib/view/view_auth_page.dart
+++ b/lib/view/view_auth_page.dart
@@ -245,7 +245,7 @@ class ViewAuthPageState extends State<ViewAuthPage> {
       try {
         assert(
           state.phoneVerificationCode != null &&
-              state.phoneVerificationCode.toString().length == 6,
+              state.phoneVerificationCode!.length == 6,
           'Enter valid confirmation code',
         );
         assert(
@@ -253,7 +253,7 @@ class ViewAuthPageState extends State<ViewAuthPage> {
           'Please input sms code received after verifying phone number',
         );
         final UserCredential credential = await webConfirmationResult!.confirm(
-          state.phoneVerificationCode.toString(),
+          state.phoneVerificationCode!,
         );
         final User user = credential.user!;
         final User currentUser = _auth.currentUser!;
@@ -281,12 +281,12 @@ class ViewAuthPageState extends State<ViewAuthPage> {
         assert(state.verificationId != null, 'VerificationId missing');
         assert(
           state.phoneVerificationCode != null &&
-              state.phoneVerificationCode.toString().length == 6,
+              state.phoneVerificationCode!.length == 6,
           'Enter valid confirmation code',
         );
         final AuthCredential credential = PhoneAuthProvider.credential(
           verificationId: state.verificationId!,
-          smsCode: state.phoneVerificationCode.toString(),
+          smsCode: state.phoneVerificationCode!,
         );
         final User user = (await _auth.signInWithCredential(credential)).user!;
         final User currentUser = _auth.currentUser!;
@@ -765,11 +765,20 @@ class ViewAuthPageState extends State<ViewAuthPage> {
         width: double.maxFinite,
         child: InputData(
           value: state.phoneVerificationCode,
-          type: InputDataType.int,
+          type: InputDataType.string,
           keyboardType: TextInputType.number,
           hintText: locales.get('page-auth--input--verification-code'),
           maxLength: 6,
+          inputFormatters: [
+            FilteringTextInputFormatter.singleLineFormatter,
+            FilteringTextInputFormatter.digitsOnly,
+          ],
           onChanged: (value) {
+            state.phoneVerificationCode = (value ?? '').replaceAll(
+              RegExp(r'\D'),
+              '',
+            );
+
             state.phoneVerificationCode = value;
             if (mounted) setState(() {});
           },
@@ -780,7 +789,7 @@ class ViewAuthPageState extends State<ViewAuthPage> {
           onSubmit: (value) {
             state.phoneVerificationCode = value;
             if (!(state.phoneVerificationCode != null &&
-                state.phoneVerificationCode.toString().length == 6)) {
+                state.phoneVerificationCode!.length == 6)) {
               return;
             }
             if (mounted) setState(() {});
@@ -795,7 +804,7 @@ class ViewAuthPageState extends State<ViewAuthPage> {
       spacerLarge,
     ];
     if (state.phoneVerificationCode != null &&
-        state.phoneVerificationCode.toString().length == 6) {
+        state.phoneVerificationCode!.length == 6) {
       sectionsPhoneVerification.add(
         actionButton(
           label: locales.get('label--sign-in-with-phone'),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fabric_flutter
 description: Native components and helpers
-version: 2.1.7
+version: 2.1.8
 
 environment:
   sdk: ^3.10.7


### PR DESCRIPTION
This pull request updates the phone verification code handling in the authentication flow to use a `String` type instead of `int`, ensuring better compatibility with user input and improving validation. It also enhances the Google sign-in logic to more robustly handle access tokens and input formatting for the verification code field.

**Phone Verification Code Handling:**

* Changed `phoneVerificationCode` in `StateViewAuth` from `int?` to `String?`, updating its getter, setter, and all usages to treat the code as a string. This avoids issues with leading zeros and simplifies validation. [[1]](diffhunk://#diff-4682bd5926c9ff47004393d7d58b8899186a0664622e81d09fa38a417f80b1b1L18-R22) [[2]](diffhunk://#diff-e3bec3bc1fd02d93723057b1d3192641e00c9057a9600b842d231f4f6714768aL248-R256) [[3]](diffhunk://#diff-e3bec3bc1fd02d93723057b1d3192641e00c9057a9600b842d231f4f6714768aL284-R289) [[4]](diffhunk://#diff-e3bec3bc1fd02d93723057b1d3192641e00c9057a9600b842d231f4f6714768aL783-R803) [[5]](diffhunk://#diff-e3bec3bc1fd02d93723057b1d3192641e00c9057a9600b842d231f4f6714768aL798-R818)
* Updated the phone verification input field to use `InputDataType.string` and added input formatters to restrict input to digits only, ensuring only valid codes are accepted.

**Google Sign-In Improvements:**

* Improved the Google sign-in flow to assert that at least one of `accessToken` or `idToken` is present, and to use the preferred token when available, providing clearer error messages if neither is present.

**Other:**

* Bumped the package version to `2.1.8` in `pubspec.yaml`.