### PR TITLE
Refactor fullscreen logic and update dependencies for Dart 3.11.5

### DIFF
--- a/lib/component/filter_menu.dart
+++ b/lib/component/filter_menu.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
@@ -724,6 +725,8 @@ class _FilterMenuState extends State<FilterMenu> {
     final theme = Theme.of(context);
     final width = MediaQuery.of(context).size.width;
     final isSmallScreen = width < 600;
+    // The max size for an iPad screen is 1366, so we consider medium screen between 600 and 1366
+    final isMediumScreen = width >= 600 && width < 1366;
 
     /// Ignore options that are included on the filters data
     List<FilterData> pendingOptions = data
@@ -801,7 +804,11 @@ class _FilterMenuState extends State<FilterMenu> {
     if (pendingOptions.isNotEmpty) {
       menuOptions.add(
         SearchAnchor(
-          isFullScreen: isSmallScreen || pendingOptions.length > 10,
+          isFullScreen: kIsWeb == true ? true : null,
+          // isFullScreen:
+          //     kIsWeb ||
+          //     isSmallScreen ||
+          //     (isMediumScreen && pendingOptions.length >= 10),
           searchController: searchController,
           builder: (BuildContext context, SearchController controller) {
             return PointerInterceptor(

--- a/lib/component/input_data.dart
+++ b/lib/component/input_data.dart
@@ -976,7 +976,11 @@ getValue -------------------------------------
           endWidget = SearchAnchor(
             key: ValueKey('input-data-${widget.type}'),
             viewHintText: locales.get('label--search'),
-            isFullScreen: kIsWeb || isSmallScreen || isMediumScreen,
+            // isFullScreen:
+            //     kIsWeb ||
+            //     isSmallScreen ||
+            //     (isMediumScreen && dropdownOptions.length >= 10),
+            isFullScreen: kIsWeb == true ? true : null,
             viewLeading: BackButton(onPressed: _closeSearch),
             viewTrailing: [
               if (value != null && value.toString().isNotEmpty)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: bda3b7b55958bfd867addc40d067b4b11f7b8846d57671f5b5a6e7f9a56fe3ad
+      sha256: cc2ad182e5b3929a1a87a8eaf35413d8bb4baa4efec124bab3e538096cdbff0d
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.69"
+    version: "1.3.70"
   analyzer:
     dependency: transitive
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "521daf8d189deb79ba474e43a696b41c49fb3987818dbacf3308f1e03673a75e"
+      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.1"
+    version: "2.15.0"
   built_collection:
     dependency: transitive
     description:
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -157,50 +157,50 @@ packages:
     dependency: "direct main"
     description:
       name: cloud_firestore
-      sha256: "3ac242332166ae5037bd87bc343744bb96d88d7b13f791492b00958ce5cc6c63"
+      sha256: de0ba027f07bd9a4f215e12e9195f14bb977b20ded0c266a396a7d1afde8ce3e
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.4.0"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
-      sha256: "1bd08b736e1015e8bf5448f5ef67b2087a2380c2c1c7972f8403c1c7b41f5359"
+      sha256: abccb2d620dbd36ccde36eee15be1627bf812d386d592b99a95854997e62fbc9
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "8.0.0"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
-      sha256: "18617275ffa2331d3ea058c515ef218bcce2ae13a14bee922563ca6ae2507c26"
+      sha256: "8f39882335b0b8be8ae33149dab147db860cb830171f95d720b43a9f16bb649a"
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.0"
+    version: "5.4.0"
   cloud_functions:
     dependency: "direct main"
     description:
       name: cloud_functions
-      sha256: "036aa4f3b880935bda48fd6ab516e0f11686c328a46313226b9cbad9220b4c59"
+      sha256: f8d5fcbc25991e1d7d95a8744731aae4129bada2283d780706731a5f599cc87b
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "6.3.0"
   cloud_functions_platform_interface:
     dependency: transitive
     description:
       name: cloud_functions_platform_interface
-      sha256: "2a52ee909011b0f33ae2074b7a431bc2d7fff4618948d93d5e71830688e0733f"
+      sha256: eef1a337609a9172d7b0ef7587767a3ec456b980eb612244b4ba71357cf3ac1c
       url: "https://pub.dev"
     source: hosted
-    version: "5.8.12"
+    version: "6.0.0"
   cloud_functions_web:
     dependency: transitive
     description:
       name: cloud_functions_web
-      sha256: be032545ca1621248ffd251930952835593a9b8136895379930cecea766379a4
+      sha256: "2673930d7e86cc82393daaca5b296b80ff269b2be6859b343abef651accdd1ac"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.5"
+    version: "5.1.6"
   code_assets:
     dependency: transitive
     description:
@@ -209,14 +209,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
-  code_builder:
-    dependency: transitive
-    description:
-      name: code_builder
-      sha256: "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.11.1"
   collection:
     dependency: "direct main"
     description:
@@ -309,10 +301,10 @@ packages:
     dependency: "direct main"
     description:
       name: dlibphonenumber
-      sha256: df96f4bdb14b0a47664de8ec7cd1de92e4e9b9bc4e34330d2da9088b0ba71e59
+      sha256: "5b38e3dcff241ddfb53fda35a4e6df360b8bde10b8a8482e08cfcc1ffc4d2c5f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.62"
+    version: "1.1.63"
   equatable:
     dependency: transitive
     description:
@@ -389,146 +381,146 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_analytics
-      sha256: "6993e54441e96b4de1dd85a159b236bbcd2c2487215c9d02b12c1685ddfded73"
+      sha256: c0bd7c2cd62dfaa11473cba23046c56f708d12f76dbc7ea6850975f19acace07
       url: "https://pub.dev"
     source: hosted
-    version: "12.3.0"
+    version: "12.4.0"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_analytics_platform_interface
-      sha256: ac2a17484daf380b2247b9874e675ff9e4ac611d839a10b91b7445f764756760
+      sha256: "35786263e413b2eb066b3c06a00ea7982cf381562aac84de70e204af4671953e"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "6.0.0"
   firebase_analytics_web:
     dependency: transitive
     description:
       name: firebase_analytics_web
-      sha256: "167a3115e71501ba6706235f00e370072920ee8d26b44fbfb9dc8e63c98a8d9b"
+      sha256: "31c216fa2ceda1fa9596e4f2cf601c5372417c86d42b4da881ab4fe9af4eadcd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1+5"
+    version: "0.6.1+6"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
-      sha256: b12cb1e2e87797d27e0041100b73ebf890dbafcff2e7e991d4593f5e8e309808
+      sha256: d9154edce12f08d82433ffa6be68e4974a174158bdb837b6685ede69ccb673eb
       url: "https://pub.dev"
     source: hosted
-    version: "6.4.0"
+    version: "6.5.0"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
-      sha256: c71517b3c78480be42789b05316a7692d69296c17848bd6a9e798300abae1ec7
+      sha256: d1912aae7ac966f745f53bb806040b8a8f32911e8c5ea6255bf42ef52a54da5a
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.9"
+    version: "9.0.0"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
-      sha256: "52b0224eb46b09f387e99710707be2d3f48da67c74fe14202e4b942cbe8ce9fd"
+      sha256: d055d27d5149ffd59d14719de86ba4dcb43333f249d8438e325c616488b7be24
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.5"
+    version: "6.2.0"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: d5a94b884dcb1e6d3430298e94bfe002238094cdfd5e29202d536ee2120f9158
+      sha256: "15bf6f85a6c8cf786344b2f163350428fc4bce105bc5332d42fb951d90b7664e"
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.0"
+    version: "4.8.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: "0ecda14c1bfc9ed8cac303dd0f8d04a320811b479362a9a4efb14fd331a473ce"
+      sha256: "7aafd426ad1926cfb1a7e9e012df5eff7d9a55200b31b04bc65ef45329ea5dee"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.3"
+    version: "7.0.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: dc5096257cd67292d34d78ceeb90836f02a4be921b5f3934311a02bb2376118c
+      sha256: "73b01cba93a4f673596a7664f8265eb538f007a84a8f5880359db8ff76c3471b"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.0"
+    version: "3.6.1"
   firebase_database:
     dependency: "direct main"
     description:
       name: firebase_database
-      sha256: "9b527722dfb154692f4e9f3a3c38dd6f6a49c1849b01d9b4fe1b9e420bb98030"
+      sha256: "7daae821129860efef0623f4adddad5cf8990e86477c90961b39d4af667856ee"
       url: "https://pub.dev"
     source: hosted
-    version: "12.3.0"
+    version: "12.4.0"
   firebase_database_platform_interface:
     dependency: transitive
     description:
       name: firebase_database_platform_interface
-      sha256: b39da15c2a7399aac55f437ebd48d9b325f8c6310d792d80d1812efd91d4a8cf
+      sha256: "1324dcdc56aac1fafa3a80ea9fbb998f00b2180c9aebc78e7efb8d5846ef2d71"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.1+1"
+    version: "0.4.0"
   firebase_database_web:
     dependency: transitive
     description:
       name: firebase_database_web
-      sha256: c592343817b0fef558715d752b11d054b55aef393c4b0b826659b106a1e4d79c
+      sha256: "1932d7b84ddcea9340ae4206d3d97916f9700c7722c03e35821a6df0c1672277"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.7+6"
+    version: "0.2.7+7"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      sha256: e5c93e8e7a9b0513f94bb684d2cf100e32e7dcdf2949574386b1955fc9a9b96a
+      sha256: "4ebb881070b40038d61799cff914b18a44649e2e47ab444fc32055c3d6bf2df0"
       url: "https://pub.dev"
     source: hosted
-    version: "16.2.0"
+    version: "16.2.1"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: "8cbb7d842e5071bba836452aff262f7db4b14bb3a0d00c1896cf176df886d65a"
+      sha256: "50eb5e125ec38b4b0b900c9f096ec94f2eeb4243d5668604f1dea24340bdb428"
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.9"
+    version: "4.7.10"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: "8750bacf50573c0383535fc3f9c58c6a2f9dff5320a16a82c30631b9dad894f1"
+      sha256: "1dfd311e764ac42be99a0aa8d9d5f7602774085af4f873658769f1438f8af918"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.5"
+    version: "4.1.6"
   firebase_storage:
     dependency: "direct main"
     description:
       name: firebase_storage
-      sha256: "825a5a64addc66b57a2e793b5e40343d1364e8b5a2a0d7e6cfc116ae9c021fbd"
+      sha256: cc0299c8f294054065b3cf75013eb4730b86ba4929be2e49d6a7c18c6bf54920
       url: "https://pub.dev"
     source: hosted
-    version: "13.3.0"
+    version: "13.4.0"
   firebase_storage_platform_interface:
     dependency: transitive
     description:
       name: firebase_storage_platform_interface
-      sha256: f910990a2fed456756bdce72ea58e86b4b3f8da4706ac7fe0d3b15ac3dffc0f0
+      sha256: "735e4dba64724e489a00de8971c0583d0c5d380110a6947904b8e9823844ac7a"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.20"
+    version: "6.0.0"
   firebase_storage_web:
     dependency: transitive
     description:
       name: firebase_storage_web
-      sha256: "80abcaca8e39c594b97a92099e5ac66787638cd3c5f85b663deb29e10820f00a"
+      sha256: "98664ab1bce765731db20df333136e59bc98e9d4cd45976c2ef0a33402fa34b9"
       url: "https://pub.dev"
     source: hosted
-    version: "3.11.5"
+    version: "3.11.6"
   fixnum:
     dependency: transitive
     description:
@@ -960,18 +952,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -1349,10 +1341,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:
@@ -1618,5 +1610,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.7 <4.0.0"
+  dart: ">=3.11.5 <4.0.0"
   flutter: ">=3.38.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,9 @@
 name: fabric_flutter
 description: Native components and helpers
-version: 2.1.8
+version: 2.2.0
 
 environment:
-  sdk: ^3.10.7
+  sdk: ^3.11.5
 
 dependencies:
   flutter:
@@ -14,14 +14,14 @@ dependencies:
     sdk: flutter
   devicelocale: ^0.8.2
   provider: ^6.1.5+1
-  firebase_core: ^4.7.0
-  cloud_firestore: ^6.3.0
-  cloud_functions: ^6.2.0
-  firebase_analytics: ^12.3.0
-  firebase_auth: ^6.4.0
-  firebase_messaging: ^16.2.0
-  firebase_storage: ^13.3.0
-  firebase_database: ^12.3.0
+  firebase_core: ^4.8.0
+  cloud_firestore: ^6.4.0
+  cloud_functions: ^6.3.0
+  firebase_analytics: ^12.4.0
+  firebase_auth: ^6.5.0
+  firebase_messaging: ^16.2.1
+  firebase_storage: ^13.4.0
+  firebase_database: ^12.4.0
   json_annotation: ^4.11.0
   image_picker: ^1.2.2
   file_picker: ^11.0.2
@@ -45,7 +45,7 @@ dependencies:
   pointer_interceptor: ^0.10.1+2
   omni_datetime_picker: ^2.3.1
   collection: ^1.19.1
-  dlibphonenumber: ^1.1.62
+  dlibphonenumber: ^1.1.63
   scrollable_positioned_list: ^0.3.8
   gap: ^3.0.1
   google_sign_in_web: ^1.1.3
@@ -58,7 +58,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
-  build_runner: 2.13.1
+  build_runner: ^2.15.0
   json_serializable: ^6.13.2
 
 #dependency_overrides:


### PR DESCRIPTION
This pull request updates dependencies, adjusts UI logic for search menus, and bumps the SDK and package version. The most important changes are grouped below:

### Dependency and SDK updates

* Upgraded Flutter SDK requirement to `^3.11.5` and bumped the package version to `2.2.0` in `pubspec.yaml`. (Fedbb3b6R1)
* Updated several dependencies to their latest versions, including all `firebase_*` packages, `dlibphonenumber`, and `build_runner`. [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L17-R24) [[2]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L48-R48) [[3]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L61-R61)

### UI and logic changes for search menus

* Modified the logic for the `isFullScreen` property in `SearchAnchor` widgets within `filter_menu.dart` and `input_data.dart` to always use fullscreen mode on web (`kIsWeb`), and otherwise set it to `null` (previous logic was more complex and based on screen size and option count). [[1]](diffhunk://#diff-a09c96a9631a815911533eedb6ac572f669f16b402a365ecc753421514388ba6L804-R811) [[2]](diffhunk://#diff-e471d0054ec6c48e6e37599480cea4411aaa413761e7ad7c41ec11eb8440b18cL979-R983)
* Added detection for "medium screen" sizes (between 600 and 1366 pixels wide) in `_FilterMenuState` to support future responsive logic, though the new value is not yet used in the active code.

### Other improvements

* Added a missing import for `flutter/foundation.dart` in `filter_menu.dart` to support the use of `kIsWeb`.