### PR TITLE
perf(localization): cache RegExp patterns in AppLocalizations

### DIFF
--- a/lib/helper/app_localizations_delegate.dart
+++ b/lib/helper/app_localizations_delegate.dart
@@ -20,6 +20,28 @@ class AppLocalizations {
   /// Identifies the active locale used when selecting translated strings.
   final Locale locale;
 
+  /// Validates that a key path contains at least one usable token.
+  ///
+  /// Compiled once and reused so [_mergeLocales] does not rebuild it on every
+  /// lookup, which happens for essentially every localized label in the tree.
+  static final RegExp _keyPathExp = RegExp(r'([a-zA-Z\d_-]+)');
+
+  /// Matches `{placeholder}` tokens when substituting option values.
+  ///
+  /// Shared across calls to [_replaceOptions] to avoid recompiling the pattern
+  /// on every message that carries options.
+  static final RegExp _placeholderExp = RegExp(r'{.*?}');
+
+  /// Strips characters that are not valid in a normalized key.
+  ///
+  /// Reused by [get] instead of being recompiled on each invocation.
+  static final RegExp _invalidCharsExp = RegExp(r'([^a-zA-Z\d-]+)');
+
+  /// Detects camelCase boundaries so they can be split with a dash.
+  ///
+  /// Reused by [get] instead of being recompiled on each invocation.
+  static final RegExp _camelCaseExp = RegExp(r'(?<=[a-z])[A-Z]');
+
   /// Returns whether an [AppLocalizations] instance is available in [context].
   ///
   /// This private guard lets [of] fall back to English when localization state
@@ -66,10 +88,9 @@ class AppLocalizations {
   /// exists. That behavior makes missing labels visible during development while
   /// still keeping the app functional.
   String _mergeLocales(String keyPath) {
-    RegExp regExp = RegExp(r'([a-zA-Z\d_-]+)');
     String finalResponse = '';
     try {
-      assert(regExp.hasMatch(keyPath));
+      assert(_keyPathExp.hasMatch(keyPath));
       if (keys.containsKey(keyPath)) {
         if (keys[keyPath]!.containsKey('en')) {
           finalResponse = keys[keyPath]!['en']!;
@@ -94,8 +115,7 @@ class AppLocalizations {
   /// keep localization lookup non-fatal.
   String _replaceOptions(String text, Map<String, String> options) {
     String result = text;
-    RegExp regExp = RegExp(r'{.*?}');
-    Iterable matches = regExp.allMatches(text);
+    Iterable matches = _placeholderExp.allMatches(text);
     if (matches.isNotEmpty) {
       for (var match in matches) {
         try {
@@ -134,16 +154,14 @@ class AppLocalizations {
     keyFinal = keyFinal.replaceAll('_', '-');
     try {
       // Remove invalid characters
-      RegExp regExp = RegExp(r'([^a-zA-Z\d-]+)');
-      keyFinal = keyFinal.replaceAll(regExp, '');
+      keyFinal = keyFinal.replaceAll(_invalidCharsExp, '');
     } catch (e) {
       //
     }
     try {
       // Handle camelCase
-      RegExp exp = RegExp(r'(?<=[a-z])[A-Z]');
       keyFinal = keyFinal.replaceAllMapped(
-        exp,
+        _camelCaseExp,
         (Match m) => ('-${m.group(0)!}'),
       );
     } catch (e) {

--- a/test/helper/app_localizations_delegate_test.dart
+++ b/test/helper/app_localizations_delegate_test.dart
@@ -1,0 +1,110 @@
+import 'package:fabric_flutter/helper/app_localizations_delegate.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppLocalizations', () {
+    group('get', () {
+      test('should return non-key values unchanged', () {
+        // Arrange
+        final localizations = AppLocalizations(const Locale('en', 'US'));
+
+        // Act
+        final result = localizations.get('Plain Text');
+
+        // Assert
+        expect(result, 'Plain Text');
+      });
+
+      test('should resolve a known key to its English label', () async {
+        // Arrange
+        final localizations = AppLocalizations(const Locale('en', 'US'));
+        await localizations.load();
+
+        // Act
+        final result = localizations.get('label--accept');
+
+        // Assert
+        expect(result, isNot('label--accept'));
+        expect(result, isNotEmpty);
+      });
+
+      test(
+        'should localize a known key using the active language code',
+        () async {
+          // Arrange
+          final localizations = AppLocalizations(const Locale('es', 'ES'));
+          await localizations.load();
+
+          // Act
+          final english = AppLocalizations(const Locale('en', 'US'));
+          await english.load();
+          final spanishLabel = localizations.get('label--accept');
+          final englishLabel = english.get('label--accept');
+
+          // Assert
+          expect(spanishLabel, isNotEmpty);
+          expect(spanishLabel, isNot(englishLabel));
+        },
+      );
+
+      test('should normalize camelCase and underscore keys consistently', () {
+        // Arrange
+        final localizations = AppLocalizations(const Locale('en', 'US'));
+
+        // Act
+        final camel = localizations.get('label--myCustomKey');
+        final underscore = localizations.get('label--my_custom_key');
+
+        // Assert
+        expect(camel, 'label--my-custom-key');
+        expect(underscore, camel);
+      });
+
+      test('should substitute placeholder options', () async {
+        // Arrange
+        final localizations = AppLocalizations(const Locale('en', 'US'));
+        localizations.keys = {
+          'label--greeting': {'en': 'Hello {name}'},
+        };
+        await localizations.load();
+
+        // Act
+        final result = localizations.get('label--greeting', {
+          'name': 'Copilot',
+        });
+
+        // Assert
+        expect(result, 'Hello Copilot');
+      });
+
+      test('should leave unknown placeholders untouched', () async {
+        // Arrange
+        final localizations = AppLocalizations(const Locale('en', 'US'));
+        localizations.keys = {
+          'label--greeting': {'en': 'Hello {name}'},
+        };
+        await localizations.load();
+
+        // Act
+        final result = localizations.get('label--greeting', {'other': 'value'});
+
+        // Assert
+        expect(result, 'Hello {name}');
+      });
+
+      test('should stay stable across repeated calls', () {
+        // Arrange
+        final localizations = AppLocalizations(const Locale('en', 'US'));
+
+        // Act
+        final first = localizations.get('label--sampleKey');
+        final second = localizations.get('label--sampleKey');
+
+        // Assert
+        expect(first, 'label--sample-key');
+        expect(second, first);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements the highest-impact / lowest-effort item from a performance review of the package: `AppLocalizations` recompiled constant `RegExp` patterns on **every** call to `get()`, which runs for essentially every localized label rendered in the widget tree.

This hoists the four constant patterns into `static final` fields so they compile once and are reused, with **no behavior change**.

### Change
In `lib/helper/app_localizations_delegate.dart`:
- `_keyPathExp` — `([a-zA-Z\d_-]+)` (was rebuilt in `_mergeLocales`)
- `_placeholderExp` — `{.*?}` (was rebuilt in `_replaceOptions`)
- `_invalidCharsExp` — `([^a-zA-Z\d-]+)` (was rebuilt in `get`)
- `_camelCaseExp` — `(?<=[a-z])[A-Z]` (was rebuilt in `get`)

The per-tag `RegExp.escape(tag)` pattern in `_replaceOptions` is intentionally left inline since it is dynamic per placeholder.

## Test plan
- Added `test/helper/app_localizations_delegate_test.dart` covering key resolution, camelCase/underscore normalization, locale fallback (en/es), and placeholder substitution to lock in unchanged behavior.
- `flutter analyze` — no issues.
- `flutter test` — full suite green (279 existing + 7 new).

## Other opportunities identified (not in this PR)
A broader review surfaced ~10 additional candidates for follow-up, e.g. per-build `RegExp` in `section_title.dart`, `logs_list.dart`, `input_data.dart` input formatters, `refreshImage()` side effects in `profile_edit.dart` `build()`, and repeated `.firstWhere()`/`.sort()` in `filter_menu.dart`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>