### PR TITLE
perf(components): hoist build-time RegExp in SectionTitle and LogsList

### DIFF
--- a/lib/component/logs_list.dart
+++ b/lib/component/logs_list.dart
@@ -55,6 +55,12 @@ class LogsList extends StatelessWidget {
   /// Provides the [EdgeInsetsGeometry] applied around the entire list.
   final EdgeInsetsGeometry margin;
 
+  /// Matches `{placeholder}` markers used to highlight inline log segments.
+  ///
+  /// Compiled once and shared across builds so the pattern is not rebuilt every
+  /// time the list renders.
+  static final RegExp _placeholderExp = RegExp(r'{.*?}', multiLine: true);
+
   /// Builds the log list for the current [BuildContext].
   ///
   /// Returns an empty [SizedBox] when [logs] is `null` or empty so parents can
@@ -65,7 +71,6 @@ class LogsList extends StatelessWidget {
     final textTheme = theme.textTheme;
     Widget container = const SizedBox(height: 0);
     if (logs == null || logs!.isEmpty) return container;
-    RegExp regExp = RegExp(r'{.*?}', multiLine: true);
 
     Widget getItem(LogsData item) {
       DateTime? timestamp = item.timestamp ?? DateTime.now();
@@ -80,7 +85,7 @@ class LogsList extends StatelessWidget {
         color: highlightColor ?? textThemeBase.color ?? Colors.black,
         fontWeight: FontWeight.w600,
       );
-      Iterable matches = regExp.allMatches(text);
+      Iterable matches = _placeholderExp.allMatches(text);
       final timestampWidget = Padding(
         padding: const EdgeInsets.only(bottom: 4.0),
         child: Text(

--- a/lib/component/section_title.dart
+++ b/lib/component/section_title.dart
@@ -38,6 +38,12 @@ class SectionTitle extends StatelessWidget {
   /// Overrides the default text style used for [description].
   final TextStyle? descriptionStyle;
 
+  /// Matches `{emphasis}` markers used to highlight inline segments.
+  ///
+  /// Compiled once and shared across builds so the pattern is not rebuilt every
+  /// time the widget renders.
+  static final RegExp _emphasisExp = RegExp(r'{.*?}', multiLine: true);
+
   /// Builds the section title and highlights any marked important segments.
   ///
   /// The widget keeps its bottom safe-area inset disabled because it is commonly
@@ -50,8 +56,6 @@ class SectionTitle extends StatelessWidget {
     TextStyle? defaultDescriptionStyle =
         descriptionStyle ?? textTheme.bodyMedium;
 
-    RegExp regExp = RegExp(r'{.*?}', multiLine: true);
-
     /// Converts brace-delimited fragments into highlighted [TextSpan] segments.
     ///
     /// Underscores are replaced with spaces so lightweight content templates can
@@ -60,7 +64,7 @@ class SectionTitle extends StatelessWidget {
       List<TextSpan> text = [];
       String textFinal = textConvert;
       int? initialHelper = 0;
-      Iterable matches = regExp.allMatches(textFinal);
+      Iterable matches = _emphasisExp.allMatches(textFinal);
       if (matches.isNotEmpty) {
         for (var match in matches) {
           if (match.start > initialHelper) {

--- a/test/component/logs_list_test.dart
+++ b/test/component/logs_list_test.dart
@@ -1,0 +1,74 @@
+import 'package:fabric_flutter/component/logs_list.dart';
+import 'package:fabric_flutter/serialized/logs_data.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Collects every [TextSpan] in [root] into a flat list for inspection.
+List<TextSpan> _flatten(InlineSpan root) {
+  final spans = <TextSpan>[];
+  void visit(InlineSpan span) {
+    if (span is TextSpan) {
+      spans.add(span);
+      final children = span.children;
+      if (children != null) {
+        for (final child in children) {
+          visit(child);
+        }
+      }
+    }
+  }
+
+  visit(root);
+  return spans;
+}
+
+void main() {
+  group('LogsList', () {
+    testWidgets('should render an empty box when there are no logs', (
+      tester,
+    ) async {
+      // Arrange & Act
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: LogsList(logs: [])),
+        ),
+      );
+
+      // Assert
+      expect(find.byType(RichText), findsNothing);
+    });
+
+    testWidgets('should highlight brace-marked segments in a log entry', (
+      tester,
+    ) async {
+      // Arrange
+      final logs = [
+        LogsData(
+          id: '1',
+          text: 'User {updated} the record',
+          timestamp: DateTime(2024, 1, 1, 12),
+        ),
+      ];
+
+      // Act
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: LogsList(logs: logs)),
+        ),
+      );
+
+      // Assert
+      final spans = find
+          .byType(RichText)
+          .evaluate()
+          .map((e) => (e.widget as RichText).text)
+          .expand(_flatten)
+          .toList();
+      final emphasis = spans.firstWhere(
+        (span) => span.text?.trim() == 'updated',
+        orElse: () => const TextSpan(),
+      );
+      expect(emphasis.style?.fontWeight, FontWeight.w600);
+    });
+  });
+}

--- a/test/component/section_title_test.dart
+++ b/test/component/section_title_test.dart
@@ -1,0 +1,78 @@
+import 'package:fabric_flutter/component/section_title.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Collects every [TextSpan] in [root] into a flat list for inspection.
+List<TextSpan> _flatten(InlineSpan root) {
+  final spans = <TextSpan>[];
+  void visit(InlineSpan span) {
+    if (span is TextSpan) {
+      spans.add(span);
+      final children = span.children;
+      if (children != null) {
+        for (final child in children) {
+          visit(child);
+        }
+      }
+    }
+  }
+
+  visit(root);
+  return spans;
+}
+
+void main() {
+  group('SectionTitle', () {
+    testWidgets(
+      'should highlight brace-marked segments with the primary color',
+      (tester) async {
+        // Arrange
+        const primary = Color(0xFF00FF00);
+        final theme = ThemeData(
+          colorScheme: const ColorScheme.light(primary: primary),
+        );
+
+        // Act
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: theme,
+            home: const Scaffold(
+              body: SectionTitle(headline: 'Plain {emphasis} tail'),
+            ),
+          ),
+        );
+
+        // Assert
+        final richText = tester.widget<RichText>(find.byType(RichText).first);
+        final spans = _flatten(richText.text);
+        final emphasis = spans.firstWhere(
+          (span) => span.text?.trim() == 'emphasis',
+        );
+        expect(emphasis.style?.color, primary);
+        final plain = spans.firstWhere(
+          (span) => span.text?.contains('Plain') == true,
+        );
+        expect(plain.style?.color, isNot(primary));
+      },
+    );
+
+    testWidgets('should render text without markers as a single span', (
+      tester,
+    ) async {
+      // Arrange
+      const headline = 'No markers here';
+
+      // Act
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: SectionTitle(headline: headline)),
+        ),
+      );
+
+      // Assert
+      final richText = tester.widget<RichText>(find.byType(RichText).first);
+      final spans = _flatten(richText.text);
+      expect(spans.any((span) => span.text == headline), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Follow-up to #186, applying the same optimization to two widgets flagged in the performance review. `SectionTitle` and `LogsList` each recompiled `RegExp(r'{.*?}', multiLine: true)` inside `build()` to locate `{emphasis}` markers. Since the pattern is constant, this hoists it into a per-widget `static final` field so it compiles once instead of on every render (with **no behavior change**).

### Changes
- `lib/component/section_title.dart` — added `_emphasisExp` static final; `build()` now reuses it.
- `lib/component/logs_list.dart` — added `_placeholderExp` static final; `build()` now reuses it.

## Test plan
- Added `test/component/section_title_test.dart` — verifies brace-marked segments get the primary color and marker-free text renders intact.
- Added `test/component/logs_list_test.dart` — verifies emphasis highlighting on a log entry and the empty-list path.
- `flutter analyze` — no issues.
- `flutter test` — full suite green (290 tests).

## Remaining opportunities from the review
Still open for future PRs: input-formatter `RegExp`s rebuilt in `input_data.dart` `build()`, `refreshImage()` side effects inside `profile_edit.dart` `build()`, repeated `.sort()`/`.firstWhere()` in `filter_menu.dart`, un-keyed `List.generate` trees in `expansion_table.dart`, and non-`const` `charset7bit` in `gsm.dart`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>