### PR TITLE
perf(filter_menu): hoist sorted operator lists and drop dead double setState

### DIFF
--- a/lib/component/filter_menu.dart
+++ b/lib/component/filter_menu.dart
@@ -12,6 +12,33 @@ import '../serialized/filter_data.dart';
 import 'input_data.dart';
 import 'popup_entry.dart';
 
+/// Operators offered for date and numeric filters, pre-sorted by name.
+///
+/// Built once at load so the popup editor does not rebuild and re-sort the list
+/// on every [build] pass.
+final List<FilterOperator> _filterOperatorDatesOrNumbers = <FilterOperator>[
+  FilterOperator.equal,
+  FilterOperator.notEqual,
+  FilterOperator.greaterThan,
+  FilterOperator.greaterThanOrEqual,
+  FilterOperator.lessThan,
+  FilterOperator.lessThanOrEqual,
+  FilterOperator.between,
+  FilterOperator.any,
+  FilterOperator.whereIn,
+]..sort((a, b) => a.name.compareTo(b.name));
+
+/// Operators offered for exact-match filters, pre-sorted by name.
+///
+/// Built once at load so the popup editor does not rebuild and re-sort the list
+/// on every [build] pass.
+final List<FilterOperator> _filterOperatorExact = <FilterOperator>[
+  FilterOperator.equal,
+  FilterOperator.notEqual,
+  FilterOperator.any,
+  FilterOperator.whereIn,
+]..sort((a, b) => a.name.compareTo(b.name));
+
 /// Shows editable controls for a single filter inside a popup surface.
 ///
 /// The widget works on a temporary [FilterData] copy so callers can cancel the
@@ -164,25 +191,8 @@ class _FilterMenuOptionDataState extends State<FilterMenuOptionData> {
     /// Define Dropdown options depending on the InputDataType
     // Ignore FilterOperator.sort
     late List<FilterOperator> dropdownOptions;
-    List<FilterOperator> filterOperatorDatesOrNumbers = [
-      FilterOperator.equal,
-      FilterOperator.notEqual,
-      FilterOperator.greaterThan,
-      FilterOperator.greaterThanOrEqual,
-      FilterOperator.lessThan,
-      FilterOperator.lessThanOrEqual,
-      FilterOperator.between,
-      FilterOperator.any,
-      FilterOperator.whereIn,
-    ];
-    filterOperatorDatesOrNumbers.sort((a, b) => a.name.compareTo(b.name));
-    List<FilterOperator> filterOperatorExact = [
-      FilterOperator.equal,
-      FilterOperator.notEqual,
-      FilterOperator.any,
-      FilterOperator.whereIn,
-    ];
-    filterOperatorExact.sort((a, b) => a.name.compareTo(b.name));
+    final filterOperatorDatesOrNumbers = _filterOperatorDatesOrNumbers;
+    final filterOperatorExact = _filterOperatorExact;
 
     switch (widget.data.type) {
       case InputDataType.email:
@@ -506,11 +516,9 @@ class _FilterMenuOptionState extends State<FilterMenuOption> {
 
   /// Refreshes the local snapshot when inherited or widget state changes.
   ///
-  /// The temporary reset forces dependent chip content to rebuild before the
-  /// latest [FilterData] is reassigned.
+  /// Copies the latest [FilterMenuOption.data] into the local mirror and
+  /// schedules a single rebuild.
   void _update() {
-    data = FilterData(id: widget.data.id);
-    if (mounted) setState(() {});
     data = widget.data;
     if (mounted) setState(() {});
   }
@@ -804,11 +812,9 @@ class _FilterMenuState extends State<FilterMenu> {
 
   /// Refreshes local state from the latest widget configuration.
   ///
-  /// The temporary reset forces dependent widgets to rebuild before the newest
-  /// [FilterMenu.data] list is reassigned.
+  /// Copies the latest [FilterMenu.data] list into the local mirror and
+  /// schedules a single rebuild.
   void _update() {
-    data = [];
-    if (mounted) setState(() {});
     data = widget.data;
     if (mounted) setState(() {});
   }

--- a/test/component/filter_menu_test.dart
+++ b/test/component/filter_menu_test.dart
@@ -1,0 +1,104 @@
+import 'package:fabric_flutter/component/filter_menu.dart';
+import 'package:fabric_flutter/component/input_data.dart';
+import 'package:fabric_flutter/serialized/filter_data.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  group('FilterMenu', () {
+    testWidgets('should render an active filter chip with its label', (
+      tester,
+    ) async {
+      // Arrange
+      final data = [
+        FilterData(
+          id: 'name',
+          label: 'Name',
+          type: InputDataType.string,
+          operator: FilterOperator.equal,
+          value: 'Bob',
+          index: 0,
+        ),
+      ];
+
+      // Act
+      await tester.pumpWidget(_wrap(FilterMenu(data: data, onChange: (_) {})));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.textContaining('Name'), findsOneWidget);
+    });
+
+    testWidgets('should refresh the mirror when the parent swaps data', (
+      tester,
+    ) async {
+      // Arrange
+      FilterData active(String label) => FilterData(
+        id: 'name',
+        label: label,
+        type: InputDataType.string,
+        operator: FilterOperator.equal,
+        value: 'Bob',
+        index: 0,
+      );
+
+      // Act
+      await tester.pumpWidget(
+        _wrap(FilterMenu(data: [active('Name')], onChange: (_) {})),
+      );
+      await tester.pumpAndSettle();
+      await tester.pumpWidget(
+        _wrap(FilterMenu(data: [active('Fullname')], onChange: (_) {})),
+      );
+      await tester.pumpAndSettle();
+
+      // Assert — didUpdateWidget -> _update propagated the new label
+      expect(find.textContaining('Fullname'), findsOneWidget);
+      expect(find.textContaining('Name '), findsNothing);
+    });
+
+    testWidgets('should render a pending filter as an add control', (
+      tester,
+    ) async {
+      // Arrange
+      final data = [
+        FilterData(id: 'name', label: 'Name', type: InputDataType.string),
+      ];
+
+      // Act
+      await tester.pumpWidget(_wrap(FilterMenu(data: data, onChange: (_) {})));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(tester.takeException(), isNull);
+      expect(find.byType(SearchAnchor), findsOneWidget);
+    });
+  });
+
+  group('FilterMenuOptionData', () {
+    testWidgets('should build the operator editor without errors', (
+      tester,
+    ) async {
+      // Arrange
+      final data = FilterData(
+        id: 'age',
+        label: 'Age',
+        type: InputDataType.int,
+        operator: FilterOperator.equal,
+        value: '18',
+      );
+
+      // Act
+      await tester.pumpWidget(
+        _wrap(FilterMenuOptionData(data: data, onChange: (_) {})),
+      );
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(tester.takeException(), isNull);
+      expect(find.byType(FilterMenuOptionData), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fifth in the performance series (after #186–#189). Two fixes in `lib/component/filter_menu.dart`:

1. **Hoisted the two constant `FilterOperator` lists out of `build()`.** `FilterMenuOptionData.build()` allocated *and re-sorted* `filterOperatorDatesOrNumbers` and `filterOperatorExact` on every rebuild. They're constant, so they now live in file-scope lists sorted once at load (`_filterOperatorDatesOrNumbers`, `_filterOperatorExact`). The lists are only read (passed as `enums:`), never mutated in place, so sharing them is safe.

2. **Removed dead double-`setState()` in both `_update()` methods.** Each did `data = <empty>; setState(); data = widget.data; setState();`. Because `setState` only *schedules* a rebuild (it doesn't render synchronously), the intermediate empty value was never displayed — the first assignment + `setState` was pure dead work. Simplified to a single assignment + one `setState`.

Both changes are behavior-preserving.

## Test plan
- Added `test/component/filter_menu_test.dart`:
  - Active filter renders its chip label.
  - **Parent data swap** re-pumps the widget and asserts the new label propagates — directly exercising the simplified `_update` via `didUpdateWidget`.
  - Pending filter renders the `SearchAnchor` add control.
  - `FilterMenuOptionData` editor builds without errors (exercises the hoisted operator lists).
- `flutter analyze` — no issues.
- `flutter test` — full suite green (305 tests).

## Remaining opportunities from the review
- `expansion_table.dart` — un-keyed `List.generate` widget trees
- `gsm.dart` — non-`const` `charset7bit` map

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>