### PR TITLE
perf(gsm): make charset7bit and charMapToReplace const

### DIFF
--- a/lib/helper/gsm.dart
+++ b/lib/helper/gsm.dart
@@ -9,7 +9,7 @@ import '../serialized/gsm_data.dart';
 /// and segmentation logic throughout [GSM].
 /// https://github.com/vchatterji/gsm
 /// https://twiliodeved.github.io/message-segment-calculator/
-Map<String, int> charset7bit = {
+const Map<String, int> charset7bit = {
   '@': 1,
   '£': 1,
   '\$': 1,
@@ -154,7 +154,7 @@ Map<String, int> charset7bit = {
 /// The keys are Unicode code points and the values describe how unsupported
 /// input should be normalized before sending SMS content through systems that
 /// expect GSM-compatible text.
-final charMapToReplace = {
+const Map<int, Map<String, String>> charMapToReplace = {
   0: {'original': '', 'replace': ''},
   3: {'original': '', 'replace': ''},
   4: {'original': '', 'replace': ''},

--- a/test/helper/gsm_test.dart
+++ b/test/helper/gsm_test.dart
@@ -125,5 +125,18 @@ void main() {
       // Assert
       expect(result, 'a\n\nb');
     });
+
+    test('should replace unsupported characters via charMapToReplace', () {
+      // Arrange
+      // U+FF61 (fullwidth ideographic full stop) maps to '.' and
+      // U+FF64 (fullwidth ideographic comma) maps to ','.
+      const input = 'a\u{FF61}b\u{FF64}c';
+
+      // Act
+      final result = GSM.toGSM(input);
+
+      // Assert
+      expect(result, 'a.b,c');
+    });
   });
 }


### PR DESCRIPTION
## Summary

Sixth in the performance series (after #186–#190). `lib/helper/gsm.dart` declared its two lookup tables as a mutable top-level `Map<String, int> charset7bit` and a non-`const` `final charMapToReplace`, even though both are strictly read-only (only `containsKey` / index reads across `GSM`).

Marking both `const` gives a single canonical compile-time instance (no per-load allocation) and enforces immutability, matching the repo's Dart style guidance to prefer `const`.

### Changes (`lib/helper/gsm.dart`)
- `charset7bit` → `const Map<String, int>`
- `charMapToReplace` → `const Map<int, Map<String, String>>`

No behavior change — all entries are literals and neither map is ever mutated.

## Test plan
- Existing `gsm_test.dart` already exercises both maps (`getTotalLengthGSM`/`isUnicode` read `charset7bit`; `toGSM` reads `charMapToReplace`).
- Added a `GSM.toGSM` test asserting `charMapToReplace`-driven substitution (fullwidth `。`→`.`, `、`→`,`).
- `flutter analyze` — no issues.
- `flutter test` — full suite green (306 tests).

## Series wrap-up
This completes the low-effort/high-value items from the original performance review. The one remaining flagged item — un-keyed `List.generate` widget trees in `expansion_table.dart` — is a larger, higher-risk change (widget identity/keys) better suited to its own dedicated PR.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>