### PR TITLE
perf(expansion_table): stop leaking a ScrollController on every build

### DIFF
--- a/lib/component/expansion_table.dart
+++ b/lib/component/expansion_table.dart
@@ -156,6 +156,19 @@ double _widthColumn = 350;
 /// Keeping the expansion behavior in state allows the widget to toggle nested
 /// tables in place without requiring external controllers.
 class _ExpansionTableState extends State<ExpansionTable> {
+  /// Controls horizontal scrolling for the root table.
+  ///
+  /// Created once and disposed with the state so the controller is not
+  /// reallocated (and leaked) on every [build] pass.
+  final ScrollController _controllerHorizontal = ScrollController();
+
+  /// Releases the horizontal scroll controller when the widget is removed.
+  @override
+  void dispose() {
+    _controllerHorizontal.dispose();
+    super.dispose();
+  }
+
   /// Builds the current table level for the given [BuildContext].
   ///
   /// Root tables render headers and horizontal scrolling, while nested tables
@@ -172,7 +185,6 @@ class _ExpansionTableState extends State<ExpansionTable> {
       width:
           widget.dividerThickness ?? theme.dataTableTheme.dividerThickness ?? 1,
     );
-    ScrollController controllerHorizontal = ScrollController();
     final List<TableColumnWidth> tableColumns = List<TableColumnWidth>.filled(
       data.header!.length,
       const FixedColumnWidth(300.0),
@@ -436,9 +448,9 @@ class _ExpansionTableState extends State<ExpansionTable> {
           thumbVisibility: true,
           interactive: true,
           trackVisibility: true,
-          controller: controllerHorizontal,
+          controller: _controllerHorizontal,
           child: SingleChildScrollView(
-            controller: controllerHorizontal,
+            controller: _controllerHorizontal,
             scrollDirection: Axis.horizontal,
             primary: false,
             child: Flex(

--- a/test/component/expansion_table_test.dart
+++ b/test/component/expansion_table_test.dart
@@ -1,0 +1,82 @@
+import 'package:fabric_flutter/component/expansion_table.dart';
+import 'package:fabric_flutter/serialized/table_data.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+TableData _sample() => TableData(
+  header: [
+    TableColumnData(value: 'Name'),
+    TableColumnData(value: 'Age', type: TableDataType.number),
+  ],
+  rows: [
+    TableRowData(cells: ['Bob', 30]),
+    TableRowData(
+      cells: ['Ann', 25],
+      child: TableData(
+        header: [
+          TableColumnData(value: 'Name'),
+          TableColumnData(value: 'Age', type: TableDataType.number),
+        ],
+        rows: [
+          TableRowData(cells: ['Kid', 5]),
+        ],
+      ),
+    ),
+  ],
+);
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  group('ExpansionTable', () {
+    testWidgets('should render an empty box when data is null', (tester) async {
+      // Arrange & Act
+      await tester.pumpWidget(_wrap(ExpansionTable(data: null)));
+
+      // Assert
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('should render header labels and row cells', (tester) async {
+      // Arrange & Act
+      await tester.pumpWidget(_wrap(ExpansionTable(data: _sample())));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.text('Name'), findsWidgets);
+      expect(find.text('Bob'), findsOneWidget);
+      expect(find.text('Ann'), findsOneWidget);
+    });
+
+    testWidgets('should expand a nested child table when toggled', (
+      tester,
+    ) async {
+      // Arrange
+      await tester.pumpWidget(_wrap(ExpansionTable(data: _sample())));
+      await tester.pumpAndSettle();
+      expect(find.text('Kid'), findsNothing);
+
+      // Act
+      await tester.tap(find.byIcon(Icons.arrow_right).first);
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.text('Kid'), findsOneWidget);
+    });
+
+    testWidgets('should dispose cleanly when removed from the tree', (
+      tester,
+    ) async {
+      // Arrange
+      await tester.pumpWidget(_wrap(ExpansionTable(data: _sample())));
+      await tester.pumpAndSettle();
+
+      // Act — replacing the widget triggers State.dispose
+      await tester.pumpWidget(_wrap(const SizedBox()));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(tester.takeException(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Final PR in the performance series (after #186–#191). While reviewing the flagged `List.generate` usage in `expansion_table.dart`, the substantive issue turned out to be a **leaked `ScrollController`**: `ExpansionTable.build()` did `ScrollController controllerHorizontal = ScrollController();` on every build pass and never disposed it. Each rebuild leaked a controller and attached a fresh one to the horizontal `Scrollbar` / `SingleChildScrollView`.

(The `List.generate` calls themselves were left as-is: the table rows rebuild inherently, and expansion state lives in the data model — `row.active` — not widget state, so adding keys would add risk without benefit.)

### Change (`lib/component/expansion_table.dart`)
- Replaced the per-build local `ScrollController` with a lifecycle-managed field `_controllerHorizontal`, created once and released in `dispose()`.
- Both the `Scrollbar` and `SingleChildScrollView` now use the shared controller.

## Test plan
- Added `test/component/expansion_table_test.dart`:
  - Null-data renders an empty box.
  - Header labels and row cells render.
  - Tapping the expander reveals the nested child table (exercises `setState` + recursive `ExpansionTable`).
  - Removing the widget from the tree disposes cleanly with no exceptions (exercises the new `dispose`).
- `flutter analyze` — no issues.
- `flutter test` — full suite green (310 tests).

## Series complete
This closes out the actionable items from the original 10-point performance review:
| PR | Area |
|----|------|
| #186 | `AppLocalizations` RegExp caching |
| #187 | `SectionTitle`/`LogsList` build RegExp |
| #188 | `input_data.dart` RegExp hoisting |
| #189 | `profile_edit.dart` avatar memoization |
| #190 | `filter_menu.dart` sorts + dead double `setState` |
| #191 | `gsm.dart` `const` maps |
| #192 (this) | `expansion_table.dart` `ScrollController` leak |

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>