### PR TITLE
perf: fix ScrollController and TextEditingController leaks

### DIFF
--- a/lib/component/google_maps_search.dart
+++ b/lib/component/google_maps_search.dart
@@ -149,7 +149,7 @@ class _GoogleMapsSearchState extends State<GoogleMapsSearch> {
   ///
   /// Keeping a dedicated [TextEditingController] lets the state reset the field
   /// without recreating the surrounding widget tree.
-  TextEditingController textController = TextEditingController();
+  final TextEditingController textController = TextEditingController();
 
   /// Tracks how many autocomplete results are currently visible.
   ///
@@ -249,6 +249,13 @@ class _GoogleMapsSearchState extends State<GoogleMapsSearch> {
     getParentValues();
     loading = false;
     requiredFields = [...searchFields, 'geometry/location', ...widget.fields];
+  }
+
+  /// Releases the search field controller when the widget is removed from the tree.
+  @override
+  void dispose() {
+    textController.dispose();
+    super.dispose();
   }
 
   /// Resynchronizes the preview when parent-provided coordinates or labels change.

--- a/lib/component/user_add_update.dart
+++ b/lib/component/user_add_update.dart
@@ -194,6 +194,19 @@ class _UserAddUpdateState extends State<UserAddUpdate> {
   /// localized and rendered near the action buttons.
   String? error;
 
+  /// Controls vertical scrolling of the form contents.
+  ///
+  /// Created once and disposed with the state so the controller is not
+  /// reallocated (and leaked) on every [build] pass.
+  final ScrollController _controller = ScrollController();
+
+  /// Releases the scroll controller when the widget is removed from the tree.
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
   /// Resets the local user draft to match the current widget configuration.
   ///
   /// Cloning the incoming [UserData] prevents accidental mutation of parent
@@ -229,7 +242,6 @@ class _UserAddUpdateState extends State<UserAddUpdate> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final locales = AppLocalizations.of(context);
-    ScrollController controller = ScrollController();
     final height = MediaQuery.of(context).size.height;
     final passwordRegex = widget.passwordRegex ?? RegexHelper.password;
     bool canCall = sending == false;
@@ -654,9 +666,9 @@ class _UserAddUpdateState extends State<UserAddUpdate> {
         thumbVisibility: true,
         interactive: true,
         trackVisibility: true,
-        controller: controller,
+        controller: _controller,
         child: SingleChildScrollView(
-          controller: controller,
+          controller: _controller,
           padding: const EdgeInsets.only(
             bottom: 64,
             left: 16,

--- a/test/component/google_maps_search_test.dart
+++ b/test/component/google_maps_search_test.dart
@@ -1,0 +1,33 @@
+import 'package:fabric_flutter/component/google_maps_search.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  group('GoogleMapsSearch', () {
+    testWidgets('should render without throwing', (tester) async {
+      // Arrange & Act
+      await tester.pumpWidget(_wrap(const GoogleMapsSearch(apiKey: 'test')));
+      await tester.pump();
+
+      // Assert
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('should dispose cleanly when removed from the tree', (
+      tester,
+    ) async {
+      // Arrange
+      await tester.pumpWidget(_wrap(const GoogleMapsSearch(apiKey: 'test')));
+      await tester.pump();
+
+      // Act — replacing the widget triggers State.dispose
+      await tester.pumpWidget(_wrap(const SizedBox()));
+      await tester.pump();
+
+      // Assert
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/test/component/user_add_update_test.dart
+++ b/test/component/user_add_update_test.dart
@@ -1,0 +1,59 @@
+import 'package:fabric_flutter/component/user_add_update.dart';
+import 'package:fabric_flutter/serialized/user_data.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+UserAddUpdate _sample() => UserAddUpdate(
+  name: true,
+  onConfirm: (UserData data, {String? group}) async {},
+  onChanged: () async {},
+);
+
+void main() {
+  group('UserAddUpdate', () {
+    testWidgets('should render the form without throwing', (tester) async {
+      // Arrange & Act
+      await tester.pumpWidget(_wrap(_sample()));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('should reuse a single scroll controller across rebuilds', (
+      tester,
+    ) async {
+      // Arrange
+      await tester.pumpWidget(_wrap(_sample()));
+      await tester.pumpAndSettle();
+      final first = tester.widget<Scrollbar>(find.byType(Scrollbar)).controller;
+
+      // Act — trigger a rebuild
+      await tester.pumpWidget(_wrap(_sample()));
+      await tester.pumpAndSettle();
+      final second = tester
+          .widget<Scrollbar>(find.byType(Scrollbar))
+          .controller;
+
+      // Assert — the same controller instance survives the rebuild
+      expect(identical(first, second), isTrue);
+    });
+
+    testWidgets('should dispose cleanly when removed from the tree', (
+      tester,
+    ) async {
+      // Arrange
+      await tester.pumpWidget(_wrap(_sample()));
+      await tester.pumpAndSettle();
+
+      // Act — replacing the widget triggers State.dispose
+      await tester.pumpWidget(_wrap(const SizedBox()));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(tester.takeException(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Round 2 of the performance pass, targeting **controller leaks** — disposable controllers that were either reallocated every `build()` or never disposed. Both are behavior-preserving fixes.

### Fixes

1. **`user_add_update.dart`** — A `ScrollController` was constructed inside `build()` and wired into both the `Scrollbar` and `SingleChildScrollView`, but there was **no `dispose()` at all**. Every rebuild allocated a new controller and leaked the previous one. Moved it to a lifecycle-managed `final` state field, disposed in a new `dispose()` override.

2. **`google_maps_search.dart`** — The `textController` field was created once (good) but **never disposed**, leaking on widget teardown. Added a `dispose()` override and marked the field `final` (it is never reassigned).

### Tests

- `test/component/user_add_update_test.dart` — renders the form, asserts the **same** `ScrollController` instance survives a rebuild, and disposes cleanly.
- `test/component/google_maps_search_test.dart` — renders and disposes cleanly.

### Validation

- `flutter analyze` → **No issues found!**
- `flutter test` → **315 passing** (up from 310).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>