### PR TITLE
perf: hoist phone input regexes and drop orphan FocusNode allocations

### DIFF
--- a/lib/component/google_maps_search.dart
+++ b/lib/component/google_maps_search.dart
@@ -445,9 +445,7 @@ class _GoogleMapsSearchState extends State<GoogleMapsSearch> {
                                   ),
                                   onTap: () {
                                     selectLocation(item);
-                                    FocusScope.of(
-                                      context,
-                                    ).requestFocus(FocusNode());
+                                    FocusScope.of(context).unfocus();
                                   },
                                 ),
                                 const Divider(height: 1),

--- a/lib/component/phone_input.dart
+++ b/lib/component/phone_input.dart
@@ -9,6 +9,18 @@ import '../helper/options.dart';
 import '../serialized/iso_data.dart';
 import 'input_data.dart';
 
+/// Matches whitespace and phone grouping punctuation stripped from raw input.
+///
+/// Hoisted to file scope so the phone field's input formatters reuse a single
+/// compiled pattern instead of recompiling it on every [State.build].
+final RegExp _denyFormattingRegex = RegExp(r'[\s()-+]');
+
+/// Matches the digit characters permitted in the national number field.
+///
+/// Hoisted to file scope so the phone field's input formatters reuse a single
+/// compiled pattern instead of recompiling it on every [State.build].
+final RegExp _allowDigitsRegex = RegExp(r'[\d{0,15}]');
+
 /// Collects a phone number by separating country selection from the national
 /// number entry field.
 ///
@@ -403,8 +415,8 @@ class _PhoneInputState extends State<PhoneInput> {
       },
       validator: inputValidation.validatePhone,
       inputFormatters: [
-        FilteringTextInputFormatter.deny(RegExp(r'[\s()-+]')),
-        FilteringTextInputFormatter.allow(RegExp(r'[\d{0,15}]')),
+        FilteringTextInputFormatter.deny(_denyFormattingRegex),
+        FilteringTextInputFormatter.allow(_allowDigitsRegex),
         FilteringTextInputFormatter.singleLineFormatter,
       ],
       maxLength: 10,

--- a/lib/view/view_auth_page.dart
+++ b/lib/view/view_auth_page.dart
@@ -145,7 +145,7 @@ class ViewAuthPageState extends State<ViewAuthPage> {
     Future<void> resetView() async {
       loading = true;
       // Close Keyboard
-      FocusScope.of(context).requestFocus(FocusNode());
+      FocusScope.of(context).unfocus();
       state.clear();
       await Future.delayed(const Duration(seconds: 1));
       loading = false;

--- a/test/component/phone_input_test.dart
+++ b/test/component/phone_input_test.dart
@@ -1,0 +1,59 @@
+import 'package:fabric_flutter/component/phone_input.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  group('PhoneInput', () {
+    testWidgets('should render the country and phone fields', (tester) async {
+      // Arrange & Act
+      await tester.pumpWidget(_wrap(const PhoneInput(value: null)));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(tester.takeException(), isNull);
+      expect(find.byType(PhoneInput), findsOneWidget);
+    });
+
+    testWidgets('should strip grouping punctuation from typed input', (
+      tester,
+    ) async {
+      // Arrange
+      String? changed;
+      await tester.pumpWidget(
+        _wrap(
+          PhoneInput(
+            value: null,
+            country: 'US',
+            onChanged: (value) => changed = value,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Act — the deny formatter should reject spaces, parentheses, and dashes
+      await tester.enterText(find.byKey(const Key('phone-input')), '(234) 1-2');
+      await tester.pumpAndSettle();
+
+      // Assert — only digits survive in the formatted output
+      expect(changed, isNotNull);
+      expect(RegExp(r'[()\s-]').hasMatch(changed!), isFalse);
+    });
+
+    testWidgets('should dispose cleanly when removed from the tree', (
+      tester,
+    ) async {
+      // Arrange
+      await tester.pumpWidget(_wrap(const PhoneInput(value: null)));
+      await tester.pumpAndSettle();
+
+      // Act
+      await tester.pumpWidget(_wrap(const SizedBox()));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(tester.takeException(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Continuation of the performance pass, bundling two low-risk, behavior-preserving fixes.

### Fixes

1. **`phone_input.dart` — hoist per-build RegExps.** The national number field's input formatters allocated two `RegExp` objects on every `build()`. Moved them to file-scope `final`s so a single compiled pattern is reused (same class of fix as #188 for `input_data.dart`). Patterns are preserved verbatim — no behavior change.

2. **Drop orphan `FocusNode` allocations.** `google_maps_search.dart` and `view_auth_page.dart` dismissed the keyboard with `FocusScope.of(context).requestFocus(FocusNode())`, which allocates a brand-new, never-disposed `FocusNode` on every call. Replaced with the idiomatic, leak-free `FocusScope.of(context).unfocus()`.

### Tests

- `test/component/phone_input_test.dart` — renders the widget, verifies the deny formatter strips grouping punctuation (spaces/parens/dashes) from typed input, and disposes cleanly.

### Validation

- `flutter analyze` → **No issues found!**
- `flutter test` → **318 passing** (up from 315).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>