### PR TITLE
perf: hoist GSM.toGSM normalization regexes to file scope

### DIFF
--- a/lib/helper/gsm.dart
+++ b/lib/helper/gsm.dart
@@ -477,6 +477,25 @@ const Map<int, Map<String, String>> charMapToReplace = {
   65380: {'original': '、', 'replace': ','},
 };
 
+/// Matches invisible formatting marks removed during GSM normalization.
+///
+/// Excludes control characters (`\p{Cc}`) so line breaks survive. Hoisted to
+/// file scope so [GSM.toGSM] reuses one compiled pattern instead of recompiling
+/// it on every call.
+final RegExp _gsmFormattingOnlyRegex = RegExp(r'[\u2069\p{Cf}]', unicode: true);
+
+/// Matches runs of horizontal spaces collapsed to a single space.
+///
+/// Hoisted to file scope so [GSM.toGSM] reuses one compiled pattern instead of
+/// recompiling it on every call.
+final RegExp _gsmMultiSpaceRegex = RegExp(r' +');
+
+/// Matches three or more consecutive line breaks normalized to two.
+///
+/// Hoisted to file scope so [GSM.toGSM] reuses one compiled pattern instead of
+/// recompiling it on every call.
+final RegExp _gsmExtraNewlinesRegex = RegExp(r'\n{3,}');
+
 /// Calculates SMS encoding details for GSM and Unicode text.
 ///
 /// This helper mirrors common SMS gateway rules so the app can estimate how a
@@ -624,20 +643,15 @@ class GSM {
 
     /// 1. Remove U+2069 and formatting characters, BUT keep line breaks (\n)
     /// We use a "lookahead" or specific exclusion to ensure \n and \r survive
-    final RegExp formattingOnly = RegExp(
-      r'[\u2069\p{Cf}]', // Removed \p{Cc} to save your line breaks
-      unicode: true,
-    );
-
     /// Remove invisible formatting
-    newContent = newContent.replaceAll(formattingOnly, '');
+    newContent = newContent.replaceAll(_gsmFormattingOnlyRegex, '');
 
     /// 2. Replace multiple spaces with a single space
     /// Note: \s matches line breaks too, so we use ' +' to only target horizontal spaces
-    newContent = newContent.replaceAll(RegExp(r' +'), ' ');
+    newContent = newContent.replaceAll(_gsmMultiSpaceRegex, ' ');
 
     /// 3. Normalize line breaks: 3 or more becomes exactly 2
-    newContent = newContent.replaceAll(RegExp(r'\n{3,}'), '\n\n');
+    newContent = newContent.replaceAll(_gsmExtraNewlinesRegex, '\n\n');
 
     /// 3. Trim leading and trailing whitespace (including newlines)
     newContent = newContent.trim();

--- a/test/helper/gsm_test.dart
+++ b/test/helper/gsm_test.dart
@@ -138,5 +138,21 @@ void main() {
       // Assert
       expect(result, 'a.b,c');
     });
+
+    test(
+      'should remove invisible formatting marks while keeping line breaks',
+      () {
+        // Arrange
+        // U+2069 (pop directional isolate) and U+200B (zero-width space, a Cf
+        // format character) must be stripped, but the newline must survive.
+        const input = 'a\u{2069}\u{200B}\nb';
+
+        // Act
+        final result = GSM.toGSM(input);
+
+        // Assert
+        expect(result, 'a\nb');
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Continues the performance pass by hoisting the constant `RegExp` objects in `GSM.toGSM` out of the per-call path.

### Fix

`GSM.toGSM()` recompiled **three** `RegExp` objects every time it ran — one to strip invisible formatting marks (`[\u2069\p{Cf}]`), one to collapse horizontal spaces (` +`), and one to normalize 3+ line breaks (`\n{3,}`). SMS-composition flows can call this repeatedly as the user types, so the recompilation was pure repeated work. Moved all three to file-scope `final`s so a single compiled pattern is reused. Patterns and flags are preserved verbatim — no behavior change.

### Tests

- Extended `test/helper/gsm_test.dart` with a case asserting invisible formatting marks (U+2069, U+200B) are removed while line breaks survive — locking the hoisted `_gsmFormattingOnlyRegex`. The existing space/newline cases already cover the other two.

### Validation

- `flutter analyze` → **No issues found!**
- `flutter test` → **319 passing** (up from 318).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>