### PR TITLE
perf: hoist per-call date formatters and drop dead verification-code regex

### DIFF
--- a/lib/helper/filter_helper.dart
+++ b/lib/helper/filter_helper.dart
@@ -11,6 +11,12 @@ import 'log_color.dart';
 /// Identifies the query dialect used when serializing filters.
 enum SQLQueryType { sql, openSearch, bigQuery }
 
+/// Formats a [DateTime] as a `yyyy-MM-dd` date string for date filters.
+///
+/// Hoisted to file scope so [FilterHelper.valueFromType] reuses one formatter
+/// instead of constructing a new [DateFormat] on every date value it serializes.
+final DateFormat _filterDateFormat = DateFormat('yyyy-MM-dd');
+
 /// Transforms [FilterData] objects into query strings, JSON, and in-memory filters.
 ///
 /// This helper is shared by state and data layers that need to serialize the same
@@ -31,13 +37,12 @@ class FilterHelper {
     switch (dataType) {
       case InputDataType.date:
         final baseDate = (value as DateTime).toUtc();
-        final DateFormat formatter = DateFormat('yyyy-MM-dd');
         final endDateFormatted = DateTime.utc(
           baseDate.year,
           baseDate.month,
           baseDate.day,
         );
-        final formatted = formatter.format(endDateFormatted);
+        final formatted = _filterDateFormat.format(endDateFormatted);
         response = '"$formatted"';
         break;
       case InputDataType.dateTime:

--- a/lib/helper/utils.dart
+++ b/lib/helper/utils.dart
@@ -10,6 +10,12 @@ import '../serialized/user_data.dart';
 import 'enum_data.dart';
 import 'log_color.dart';
 
+/// Formats a [DateTime] as a `yyyy-MM-dd` date string.
+///
+/// Hoisted to file scope so [Utils.dateToJson] reuses one formatter instead of
+/// constructing a new [DateFormat] on every call.
+final DateFormat _dateOnlyFormat = DateFormat('yyyy-MM-dd');
+
 /// Provides general-purpose utility functions for serialization, randomness, and formatting.
 ///
 /// This class centralizes common operations that do not belong to a specific
@@ -60,7 +66,7 @@ class Utils {
   /// birthdates or calendar events.
   static String? dateToJson(DateTime? time) {
     if (time == null) return null;
-    return DateFormat('yyyy-MM-dd').format(time.toUtc()).toString();
+    return _dateOnlyFormat.format(time.toUtc()).toString();
   }
 
   /// Converts a string value to a double, returning null if conversion fails.

--- a/lib/view/view_auth_page.dart
+++ b/lib/view/view_auth_page.dart
@@ -781,11 +781,6 @@ class ViewAuthPageState extends State<ViewAuthPage> {
             FilteringTextInputFormatter.digitsOnly,
           ],
           onChanged: (value) {
-            state.phoneVerificationCode = (value ?? '').replaceAll(
-              RegExp(r'\D'),
-              '',
-            );
-
             state.phoneVerificationCode = value;
             if (mounted) setState(() {});
           },

--- a/test/helper/filter_helper_test.dart
+++ b/test/helper/filter_helper_test.dart
@@ -1,0 +1,49 @@
+import 'package:fabric_flutter/component/input_data.dart';
+import 'package:fabric_flutter/helper/filter_helper.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FilterHelper.valueFromType', () {
+    test('should return the value unchanged when it is null', () {
+      // Arrange, Act & Assert
+      expect(
+        FilterHelper.valueFromType(
+          dataType: InputDataType.date,
+          sqlQueryType: SQLQueryType.sql,
+          value: null,
+        ),
+        isNull,
+      );
+    });
+
+    test('should serialize a date value as a quoted UTC yyyy-MM-dd string', () {
+      // Arrange
+      final date = DateTime.utc(2024, 3, 7, 18, 45);
+
+      // Act
+      final result = FilterHelper.valueFromType(
+        dataType: InputDataType.date,
+        sqlQueryType: SQLQueryType.sql,
+        value: date,
+      );
+
+      // Assert
+      expect(result, '"2024-03-07"');
+    });
+
+    test('should drop time-of-day information from the serialized date', () {
+      // Arrange — a late-day timestamp must still format to its calendar date.
+      final date = DateTime.utc(2024, 12, 31, 23, 59, 59);
+
+      // Act
+      final result = FilterHelper.valueFromType(
+        dataType: InputDataType.date,
+        sqlQueryType: SQLQueryType.sql,
+        value: date,
+      );
+
+      // Assert
+      expect(result, '"2024-12-31"');
+    });
+  });
+}

--- a/test/helper/utils_test.dart
+++ b/test/helper/utils_test.dart
@@ -43,4 +43,33 @@ void main() {
       expect(a, isNot(equals(b)));
     });
   });
+
+  group('Utils.dateToJson', () {
+    test('should return null for null input', () {
+      // Arrange, Act & Assert
+      expect(Utils.dateToJson(null), isNull);
+    });
+
+    test('should format a date as a UTC yyyy-MM-dd string', () {
+      // Arrange
+      final date = DateTime.utc(2024, 3, 7, 18, 45);
+
+      // Act
+      final result = Utils.dateToJson(date);
+
+      // Assert
+      expect(result, '2024-03-07');
+    });
+
+    test('should normalize the value to UTC before formatting', () {
+      // Arrange — a local time late in the day whose UTC date may differ.
+      final date = DateTime.utc(2024, 12, 31, 23, 59).toLocal();
+
+      // Act
+      final result = Utils.dateToJson(date);
+
+      // Assert
+      expect(result, '2024-12-31');
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Eliminates repeated per-call allocations of constant formatters/regexes, and removes a dead-code path in the auth flow.

### Fixes

1. **`utils.dart` — hoist date formatter.** `Utils.dateToJson` constructed a new `DateFormat('yyyy-MM-dd')` on every call. Serialization helpers run once per record, so this was repeated work. Moved to a file-scope `final`.

2. **`filter_helper.dart` — hoist date formatter.** `FilterHelper.valueFromType` rebuilt the same `DateFormat('yyyy-MM-dd')` for every date value it serialized when composing queries. Moved to a file-scope `final`.

3. **`view_auth_page.dart` — remove dead verification-code regex.** The verification-code `onChanged` stripped non-digits into `phoneVerificationCode` via `replaceAll(RegExp(r'\D'), '')`, then **immediately overwrote** the result with the raw `value` on the next line — so the per-keystroke `RegExp` was pure dead work. The field's `digitsOnly` input formatter already guarantees digits, so the dead block is removed with no behavior change.

### Tests

- `test/helper/utils_test.dart` — new `Utils.dateToJson` group (null, UTC formatting, UTC normalization).
- `test/helper/filter_helper_test.dart` — **new file** covering `valueFromType` for the date path (null passthrough, quoted `yyyy-MM-dd`, time-of-day dropped).

### Validation

- `flutter analyze` → **No issues found!**
- `flutter test` → **325 passing** (up from 319).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>