### PR TITLE
perf: reuse a single NumberFormat for chart range-slider labels

### DIFF
--- a/lib/component/google_chart_container.dart
+++ b/lib/component/google_chart_container.dart
@@ -11,6 +11,20 @@ import 'edit_save_button.dart';
 import 'google_chart.dart';
 import 'input_data.dart';
 
+/// Formats the numeric range-slider labels shown in the chart editor.
+///
+/// Hoisted to file scope so the editor reuses a single formatter instead of
+/// constructing a new [NumberFormat] four times on every rebuild (including on
+/// every frame while the range slider is dragged).
+final NumberFormat _chartRangeFormat = NumberFormat();
+
+/// Formats [value] for a chart range-slider label using grouped digits.
+///
+/// Exposed as a pure top-level helper so the formatting can be verified without
+/// rendering the webview-backed chart, and so every call site reuses the same
+/// hoisted [NumberFormat] instance.
+String chartRangeLabel(num value) => _chartRangeFormat.format(value);
+
 /// Wraps a [GoogleChart] with optional editing controls for persisted chart settings.
 ///
 /// This widget keeps a working copy of [preferences] so callers can preview edits,
@@ -393,10 +407,8 @@ class _GoogleChartContainerState extends State<GoogleChartContainer> {
                         min: min,
                         divisions: (max / 20).floor(),
                         labels: RangeLabels(
-                          NumberFormat().format(
-                            _currentRangeValues.start.floor(),
-                          ),
-                          NumberFormat().format(_currentRangeValues.end.ceil()),
+                          chartRangeLabel(_currentRangeValues.start.floor()),
+                          chartRangeLabel(_currentRangeValues.end.ceil()),
                         ),
                         onChanged: (RangeValues values) {
                           preferencesCopy.min = values.start.floorToDouble();
@@ -428,7 +440,7 @@ class _GoogleChartContainerState extends State<GoogleChartContainer> {
                           vertical: 2,
                         ),
                         child: Text(
-                          '${locales.get('label--range')} (${NumberFormat().format(_currentRangeValues.start.floor())} - ${NumberFormat().format(_currentRangeValues.end.ceil())})',
+                          '${locales.get('label--range')} (${chartRangeLabel(_currentRangeValues.start.floor())} - ${chartRangeLabel(_currentRangeValues.end.ceil())})',
                           style: textTheme.bodySmall,
                         ),
                       ),

--- a/test/component/google_chart_container_test.dart
+++ b/test/component/google_chart_container_test.dart
@@ -1,0 +1,28 @@
+import 'package:fabric_flutter/component/google_chart_container.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('chartRangeLabel', () {
+    test('should format small integers without grouping separators', () {
+      // Arrange, Act & Assert
+      expect(chartRangeLabel(0), '0');
+      expect(chartRangeLabel(42), '42');
+    });
+
+    test('should group thousands in larger values', () {
+      // Arrange, Act & Assert
+      expect(chartRangeLabel(1000), '1,000');
+      expect(chartRangeLabel(1234567), '1,234,567');
+    });
+
+    test('should return identical output across repeated calls', () {
+      // Arrange & Act — the shared formatter must stay stateless between calls.
+      final first = chartRangeLabel(2048);
+      final second = chartRangeLabel(2048);
+
+      // Assert
+      expect(first, second);
+      expect(first, '2,048');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Removes a per-frame allocation hot spot in the chart editor's range slider.

### Fix

`GoogleChartContainer` constructed **four** `NumberFormat()` instances on every `build()` to render the range-slider labels (two in `RangeLabels`, two in the range caption). Because the slider rebuilds on every drag frame, this allocated four formatters per frame during interaction. Hoisted a single `NumberFormat` to file scope and routed all four call sites through a pure top-level `chartRangeLabel(num)` helper. Output is identical (default-locale `NumberFormat`) — no behavior change.

Extracting the helper also makes the formatting unit-testable: the chart preview is backed by a `WebView`/iframe platform view that can't be pumped in a widget test, so testing the label logic directly (à la `resolveAvatarPreview` in #189) keeps coverage without fighting the platform channel.

### Tests

- `test/component/google_chart_container_test.dart` — **new file** covering `chartRangeLabel` (no separators for small ints, thousands grouping, stable repeated calls).

### Validation

- `flutter analyze` → **No issues found!**
- `flutter test` → **328 passing** (up from 325).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>