### PR TITLE
perf: share a single DateFormat for LogsList timestamps

### DIFF
--- a/lib/component/logs_list.dart
+++ b/lib/component/logs_list.dart
@@ -61,6 +61,12 @@ class LogsList extends StatelessWidget {
   /// time the list renders.
   static final RegExp _placeholderExp = RegExp(r'{.*?}', multiLine: true);
 
+  /// Formats each entry's timestamp as a localized date and time.
+  ///
+  /// Created once and shared across builds so the formatter is not rebuilt for
+  /// every log row on every render.
+  static final DateFormat _timestampFormat = DateFormat.yMd().add_jm();
+
   /// Builds the log list for the current [BuildContext].
   ///
   /// Returns an empty [SizedBox] when [logs] is `null` or empty so parents can
@@ -89,7 +95,7 @@ class LogsList extends StatelessWidget {
       final timestampWidget = Padding(
         padding: const EdgeInsets.only(bottom: 4.0),
         child: Text(
-          DateFormat.yMd().add_jm().format(timestamp),
+          _timestampFormat.format(timestamp),
           style: textTheme.bodySmall,
         ),
       );

--- a/test/component/logs_list_test.dart
+++ b/test/component/logs_list_test.dart
@@ -2,6 +2,7 @@ import 'package:fabric_flutter/component/logs_list.dart';
 import 'package:fabric_flutter/serialized/logs_data.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
 
 /// Collects every [TextSpan] in [root] into a flat list for inspection.
 List<TextSpan> _flatten(InlineSpan root) {
@@ -69,6 +70,27 @@ void main() {
         orElse: () => const TextSpan(),
       );
       expect(emphasis.style?.fontWeight, FontWeight.w600);
+    });
+
+    testWidgets('should render the entry timestamp with the shared formatter', (
+      tester,
+    ) async {
+      // Arrange
+      final timestamp = DateTime(2024, 1, 2, 15, 30);
+      final logs = [
+        LogsData(id: '1', text: 'A log line', timestamp: timestamp),
+      ];
+      final expected = DateFormat.yMd().add_jm().format(timestamp);
+
+      // Act
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: LogsList(logs: logs)),
+        ),
+      );
+
+      // Assert
+      expect(find.text(expected), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary

Removes a per-row formatter allocation in `LogsList`.

### Fix

`LogsList` constructed a new `DateFormat.yMd().add_jm()` for **every log row** — the call lived inside the per-item `getItem` closure, so a long log timeline allocated one formatter per entry on every render. Hoisted it to a `static final` (next to the existing `_placeholderExp` pattern added in #187) so all rows reuse one formatter. Output is identical — no behavior change.

### Tests

- Extended `test/component/logs_list_test.dart` with a case asserting the rendered timestamp text matches `DateFormat.yMd().add_jm()`.

### Validation

- `flutter analyze` → **No issues found!**
- `flutter test` → **333 passing** (up from 332).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>