### PR TITLE
perf: hoist InputData time formatter to a state field

### DIFF
--- a/lib/component/input_data.dart
+++ b/lib/component/input_data.dart
@@ -509,6 +509,9 @@ class _InputDataState extends State<InputData> {
     'en_US',
   ).addPattern(' - ').add_jm();
 
+  /// Formats time-only values for display inside read-only picker fields.
+  DateFormat formatTime = DateFormat.jm();
+
   /// Stores an internally generated prefix, such as the `+` used for phone fields.
   String? prefixText;
 
@@ -1273,7 +1276,6 @@ getValue -------------------------------------
         break;
       case InputDataType.time:
         TimeOfDay? time = value;
-        DateFormat formatTime = DateFormat.jm();
         String? dateString = time != null
             ? formatTime.format(DateTime(1, 1, 1, time.hour, time.minute))
             : null;

--- a/test/component/input_data_test.dart
+++ b/test/component/input_data_test.dart
@@ -1,5 +1,9 @@
 import 'package:fabric_flutter/component/input_data.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
 
 void main() {
   group('parseValueByInputDataType', () {
@@ -80,6 +84,47 @@ void main() {
 
       // Assert
       expect(result, isNull);
+    });
+  });
+
+  group('InputData time field', () {
+    testWidgets('should render a selected time with the shared formatter', (
+      tester,
+    ) async {
+      // Arrange
+      const time = TimeOfDay(hour: 14, minute: 30);
+      final expected = DateFormat.jm().format(DateTime(1, 1, 1, 14, 30));
+
+      // Act
+      await tester.pumpWidget(
+        _wrap(const InputData(value: time, type: InputDataType.time)),
+      );
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.text(expected), findsOneWidget);
+    });
+
+    testWidgets('should dispose cleanly when removed from the tree', (
+      tester,
+    ) async {
+      // Arrange
+      await tester.pumpWidget(
+        _wrap(
+          const InputData(
+            value: TimeOfDay(hour: 9, minute: 0),
+            type: InputDataType.time,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Act
+      await tester.pumpWidget(_wrap(const SizedBox()));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(tester.takeException(), isNull);
     });
   });
 }


### PR DESCRIPTION
## Summary

Removes a per-build formatter allocation in `InputData`'s time picker.

### Fix

The `InputDataType.time` branch of `InputData.build()` constructed a new `DateFormat.jm()` on every rebuild to format the selected time label. Promoted it to a `State` field `formatTime` — mirroring the existing `formatDate` / `formatDateTime` formatters already held as fields — so the time field reuses a single instance across rebuilds. Output is identical (`DateFormat.jm()`) — no behavior change.

### Tests

- Extended `test/component/input_data_test.dart` with an `InputData time field` group: asserts a selected `TimeOfDay` renders via `DateFormat.jm()` and that the widget disposes cleanly.

### Validation

- `flutter analyze` → **No issues found!**
- `flutter test` → **335 passing** (up from 333).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>