### PR TITLE
perf: memoize ISO country/language alpha2 lookups

### DIFF
--- a/lib/helper/iso_countries.dart
+++ b/lib/helper/iso_countries.dart
@@ -4263,27 +4263,29 @@ class ISOCountries {
     return [...mainCountries, ...notMainCountries];
   }
 
+  /// Caches countries keyed by ISO 3166-1 alpha-2 code for fast metadata lookups.
+  ///
+  /// Built once from [countries] so repeated [getName] and [getFlag] calls do
+  /// not re-deserialize the full dataset and linear-scan it on every access.
+  static final Map<String, ISOCountry> _byAlpha2 = {
+    for (final country in countries) country.alpha2: country,
+  };
+
   /// Returns the display name for the country identified by [alpha2].
   ///
   /// `null` is returned for unknown codes so callers can fall back gracefully in
   /// profile, billing, or address flows.
   static String? getName(String? alpha2) {
-    try {
-      return countries.firstWhere((element) => element.alpha2 == alpha2).name;
-    } catch (error) {
-      return null;
-    }
+    if (alpha2 == null) return null;
+    return _byAlpha2[alpha2]?.name;
   }
 
   /// Returns the flag emoji for the country identified by [alpha2].
   ///
   /// `null` is returned when no matching country exists.
   static String? getFlag(String? alpha2) {
-    try {
-      return countries.firstWhere((element) => element.alpha2 == alpha2).flag;
-    } catch (error) {
-      return null;
-    }
+    if (alpha2 == null) return null;
+    return _byAlpha2[alpha2]?.flag;
   }
 
   /// Lists the country codes currently supported for phone-number purchasing.

--- a/lib/helper/iso_language.dart
+++ b/lib/helper/iso_language.dart
@@ -921,16 +921,21 @@ class ISOLanguages {
     return items;
   }
 
+  /// Caches languages keyed by ISO 639-1 alpha-2 code for fast metadata lookups.
+  ///
+  /// Built once from [languages] so repeated [getName] and [getEmoji] calls do
+  /// not re-deserialize the full dataset and linear-scan it on every access.
+  static final Map<String, ISOLanguage> _byAlpha2 = {
+    for (final language in languages) language.alpha2: language,
+  };
+
   /// Returns the display name for the language identified by [alpha2].
   ///
   /// `null` is returned when the code is unknown so UI code can decide how to
   /// handle missing metadata without catching exceptions.
   static String? getName(String? alpha2) {
-    try {
-      return languages.firstWhere((element) => element.alpha2 == alpha2).name;
-    } catch (error) {
-      return null;
-    }
+    if (alpha2 == null) return null;
+    return _byAlpha2[alpha2]?.name;
   }
 
   /// Returns the emoji marker associated with the language identified by [alpha2].
@@ -938,10 +943,7 @@ class ISOLanguages {
   /// Some entries use a globe emoji instead of a flag when no single country is a
   /// good representation of the language.
   static String? getEmoji(String? alpha2) {
-    try {
-      return languages.firstWhere((element) => element.alpha2 == alpha2).emoji;
-    } catch (error) {
-      return null;
-    }
+    if (alpha2 == null) return null;
+    return _byAlpha2[alpha2]?.emoji;
   }
 }

--- a/test/helper/iso_countries_test.dart
+++ b/test/helper/iso_countries_test.dart
@@ -72,5 +72,15 @@ void main() {
       // Arrange, Act & Assert
       expect(ISOCountries.getFlag('ZZ'), isNull);
     });
+
+    test('should return the same value across repeated cached lookups', () {
+      // Arrange & Act — the memoized lookup must stay stable between calls.
+      final first = ISOCountries.getName('CA');
+      final second = ISOCountries.getName('CA');
+
+      // Assert
+      expect(first, 'Canada');
+      expect(first, second);
+    });
   });
 }

--- a/test/helper/iso_language_test.dart
+++ b/test/helper/iso_language_test.dart
@@ -42,5 +42,15 @@ void main() {
       // Arrange, Act & Assert
       expect(ISOLanguages.getEmoji('zz'), isNull);
     });
+
+    test('should return the same value across repeated cached lookups', () {
+      // Arrange & Act — the memoized lookup must stay stable between calls.
+      final first = ISOLanguages.getName('en');
+      final second = ISOLanguages.getName('en');
+
+      // Assert
+      expect(first, 'English');
+      expect(first, second);
+    });
   });
 }


### PR DESCRIPTION
## Summary

`ISOCountries.getName`/`getFlag` and `ISOLanguages.getName`/`getEmoji` each re-deserialized the **entire** raw dataset (258 countries / dozens of languages) via the `countries`/`languages` getters and then linear-scanned it with `firstWhere` on **every call**. These run frequently in pickers, chips, and summaries.

This PR builds a memoized `alpha2 -> model` map once per helper and resolves lookups against it, turning each call from an O(n) rebuild+scan into an O(1) map read.

## Why it's safe
- The public `countries`/`languages` getters still return fresh lists, so the mutation-safety contract is unchanged.
- `alpha2` codes are **unique** in both datasets, so a map lookup returns the same entry the previous `firstWhere` did.
- `null`/unknown codes still resolve to `null` (explicit guard + missing-key semantics).

## Tests
- Existing known/unknown/null cases still pass.
- Added cached-lookup stability cases to both ISO helper tests.
- `flutter analyze`: clean. Full suite: **337 passing**.

## Behavior
No functional change — pure performance.