### PR TITLE
perf: avoid per-placeholder RegExp in localization replacement

### DIFF
--- a/lib/helper/app_localizations_delegate.dart
+++ b/lib/helper/app_localizations_delegate.dart
@@ -121,12 +121,12 @@ class AppLocalizations {
         try {
           String tag = text.substring(match.start, match.end);
           String cleanTag = tag.substring(1, tag.length - 1);
-          // Escape the tag so any regex metacharacters (like `{` or `}`)
-          // are treated literally when building the RegExp.
-          RegExp regExpTag = RegExp(RegExp.escape(tag), multiLine: true);
           String? replaceWith = options[cleanTag];
           if (replaceWith != null) {
-            result = result.replaceAll(regExpTag, replaceWith);
+            // Pass the tag as a plain string so it is replaced literally. This
+            // avoids allocating a RegExp per placeholder and treats regex
+            // metacharacters (like `{` or `}`) as literal text.
+            result = result.replaceAll(tag, replaceWith);
           }
         } catch (e) {
           // Ensure we pass a string to the logger.

--- a/test/helper/app_localizations_delegate_test.dart
+++ b/test/helper/app_localizations_delegate_test.dart
@@ -93,6 +93,44 @@ void main() {
         expect(result, 'Hello {name}');
       });
 
+      test(
+        'should replace every occurrence of a repeated placeholder',
+        () async {
+          // Arrange
+          final localizations = AppLocalizations(const Locale('en', 'US'));
+          localizations.keys = {
+            'label--echo': {'en': '{word} and {word} again'},
+          };
+          await localizations.load();
+
+          // Act
+          final result = localizations.get('label--echo', {'word': 'go'});
+
+          // Assert
+          expect(result, 'go and go again');
+        },
+      );
+
+      test(
+        'should treat replacement values with regex metacharacters literally',
+        () async {
+          // Arrange
+          final localizations = AppLocalizations(const Locale('en', 'US'));
+          localizations.keys = {
+            'label--amount': {'en': 'Total {value}'},
+          };
+          await localizations.load();
+
+          // Act
+          final result = localizations.get('label--amount', {
+            'value': r'$1.50 (a+b)',
+          });
+
+          // Assert
+          expect(result, r'Total $1.50 (a+b)');
+        },
+      );
+
       test('should stay stable across repeated calls', () {
         // Arrange
         final localizations = AppLocalizations(const Locale('en', 'US'));


### PR DESCRIPTION
## Summary

`AppLocalizations.get` powers virtually every translated label in the app. When a message carries placeholder `options`, `_replaceOptions` constructed a **fresh `RegExp`** (via `RegExp.escape`) for **each** placeholder and ran a regex `replaceAll` — even though the tag is always a literal token like `{name}`.

## Change
Replace the tag literally with `String.replaceAll(tag, value)`. A plain `String` is a literal `Pattern`, so this drops the per-placeholder `RegExp` allocation while producing identical output.

## Why it's safe
- The original escaped the tag specifically to treat regex metacharacters (`{`, `}`) as literal — a literal string pattern does exactly that.
- `String.replaceAll` with a string replacement does **not** interpret `$1`-style groups, so replacement values containing `$`/`(`/`+` are also handled literally (covered by a new test).
- Same output — pure performance + simplification.

## Tests
- Existing placeholder-substitution and unknown-placeholder tests still pass.
- Added repeated-placeholder and regex-metacharacter-value cases.
- `flutter analyze`: clean. Full suite: **342 passing**.