### PR TITLE
perf: cache localization key normalization

### DIFF
--- a/lib/helper/app_localizations_delegate.dart
+++ b/lib/helper/app_localizations_delegate.dart
@@ -42,6 +42,14 @@ class AppLocalizations {
   /// Reused by [get] instead of being recompiled on each invocation.
   static final RegExp _camelCaseExp = RegExp(r'(?<=[a-z])[A-Z]');
 
+  /// Caches normalized key paths so repeated lookups of the same raw key skip
+  /// the regex passes and lowercasing in [get].
+  ///
+  /// Normalization depends only on the incoming key string (never on [keys] or
+  /// [locale]), so a single shared cache stays correct across every instance and
+  /// after [load] or custom [keys] assignments.
+  static final Map<String, String> _normalizedKeyCache = {};
+
   /// Returns whether an [AppLocalizations] instance is available in [context].
   ///
   /// This private guard lets [of] fall back to English when localization state
@@ -150,24 +158,31 @@ class AppLocalizations {
       return key;
     }
     String keyFinal = key?.toString() ?? 'label--unknown';
-    // Fix dash
-    keyFinal = keyFinal.replaceAll('_', '-');
-    try {
-      // Remove invalid characters
-      keyFinal = keyFinal.replaceAll(_invalidCharsExp, '');
-    } catch (e) {
-      //
+    final String rawKey = keyFinal;
+    final String? cachedKey = _normalizedKeyCache[rawKey];
+    if (cachedKey != null) {
+      keyFinal = cachedKey;
+    } else {
+      // Fix dash
+      keyFinal = keyFinal.replaceAll('_', '-');
+      try {
+        // Remove invalid characters
+        keyFinal = keyFinal.replaceAll(_invalidCharsExp, '');
+      } catch (e) {
+        //
+      }
+      try {
+        // Handle camelCase
+        keyFinal = keyFinal.replaceAllMapped(
+          _camelCaseExp,
+          (Match m) => ('-${m.group(0)!}'),
+        );
+      } catch (e) {
+        //
+      }
+      keyFinal = keyFinal.toLowerCase();
+      _normalizedKeyCache[rawKey] = keyFinal;
     }
-    try {
-      // Handle camelCase
-      keyFinal = keyFinal.replaceAllMapped(
-        _camelCaseExp,
-        (Match m) => ('-${m.group(0)!}'),
-      );
-    } catch (e) {
-      //
-    }
-    keyFinal = keyFinal.toLowerCase();
     String finalLocalization = _mergeLocales(keyFinal);
     if (options != null) {
       finalLocalization = _replaceOptions(finalLocalization, options);

--- a/test/helper/app_localizations_delegate_test.dart
+++ b/test/helper/app_localizations_delegate_test.dart
@@ -143,6 +143,21 @@ void main() {
         expect(first, 'label--sample-key');
         expect(second, first);
       });
+
+      test('should normalize a key identically across instances', () {
+        // Arrange — the normalization cache is shared, so a second instance
+        // with a different locale must still normalize the raw key the same way.
+        final english = AppLocalizations(const Locale('en', 'US'));
+        final spanish = AppLocalizations(const Locale('es', 'ES'));
+
+        // Act
+        final fromEnglish = english.get('label--anotherCustomKey');
+        final fromSpanish = spanish.get('label--another_custom_key');
+
+        // Assert
+        expect(fromEnglish, 'label--another-custom-key');
+        expect(fromSpanish, fromEnglish);
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

`AppLocalizations.get` normalizes every `label--` key on each call: an underscore replace, an invalid-character regex strip, a camelCase-split regex pass, and a lowercase. This runs for **essentially every localized label on every rebuild**, repeating identical work for the same raw keys.

## Change
Normalization depends only on the incoming key string (never on `keys` or `locale`), so memoize `raw key -> normalized key` in a shared static cache and reuse it.

## Why it's safe
- Pure function of the key string — same result regardless of instance, locale, `load()`, or custom `keys` assignments.
- The subsequent `_mergeLocales` lookup and the missing-key comparison are unchanged.

## Tests
- Existing normalization / underscore-equivalence / repeat-stability tests still pass (now exercising the cache path).
- Added a cross-instance normalization case to lock shared-cache correctness.
- `flutter analyze`: clean. Full suite: **343 passing**.