### PR TITLE
perf: cache PhoneInput picker options built from stable country list

### DIFF
--- a/lib/component/phone_input.dart
+++ b/lib/component/phone_input.dart
@@ -148,6 +148,12 @@ class _PhoneInputState extends State<PhoneInput> {
   /// Stores the deduplicated list of selectable countries for mobile numbers.
   late List<ISOCountry> items;
 
+  /// Caches the dropdown options derived from [items].
+  ///
+  /// Built once in [initState] because [items] is stable after initialization,
+  /// so the picker does not regenerate this ~200-entry list on every rebuild.
+  late List<ButtonOptions> options;
+
   /// Stores the normalized output value forwarded to parent callbacks.
   String? formattedNumber;
 
@@ -274,6 +280,14 @@ class _PhoneInputState extends State<PhoneInput> {
         items[index].fullName = '${items[index].fullName}, ${element.fullName}';
       }
     }
+    options = List.generate(items.length, (index) {
+      final item = items[index];
+      return ButtonOptions(
+        label: '${item.name} (+${item.callingCode})',
+        labelAlt: '${item.fullName} ${item.alpha2}',
+        value: int.tryParse(item.callingCode!),
+      );
+    });
     _reset();
     if (widget.value != null) {
       formatInput(widget.value!);
@@ -339,14 +353,6 @@ class _PhoneInputState extends State<PhoneInput> {
       locales: locales,
       defaultCountry: selectedAlpha2.isEmpty ? 'US' : selectedAlpha2,
     );
-    List<ButtonOptions> options = List.generate(items.length, (index) {
-      final item = items[index];
-      return ButtonOptions(
-        label: '${item.name} (+${item.callingCode})',
-        labelAlt: '${item.fullName} ${item.alpha2}',
-        value: int.tryParse(item.callingCode!),
-      );
-    });
     final countryPicker = InputData(
       key: const Key('country-picker'),
       required: widget.required,

--- a/test/component/phone_input_test.dart
+++ b/test/component/phone_input_test.dart
@@ -55,5 +55,24 @@ void main() {
       // Assert
       expect(tester.takeException(), isNull);
     });
+
+    testWidgets('should keep rendering after a parent rebuild', (tester) async {
+      // Arrange — the picker options are cached in initState, so a rebuild
+      // must not throw or drop the fields.
+      await tester.pumpWidget(
+        _wrap(const PhoneInput(value: null, country: 'US')),
+      );
+      await tester.pumpAndSettle();
+
+      // Act — force a rebuild with the same configuration.
+      await tester.pumpWidget(
+        _wrap(const PhoneInput(value: null, country: 'US')),
+      );
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(tester.takeException(), isNull);
+      expect(find.byType(PhoneInput), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## Summary

`PhoneInput.build` regenerated its country dropdown options with `List.generate` over the deduplicated `items` list on **every rebuild**, allocating a `ButtonOptions` plus string interpolation and `int.tryParse` for each of the ~200 entries.

`items` is only built and mutated in `initState` and is read-only afterward, so this derived list is invariant across rebuilds.

## Change
Build `options` once in `initState` (right after `items` is finalized) and store it in a `State` field the `build` method reuses.

## Why it's safe
- `items` is never mutated after `initState` (verified: only the dedup loop writes to it).
- Rendering and picker behavior are unchanged — the widget just stops rebuilding a stable list each frame.

## Tests
- Existing render / input-formatting / dispose tests still pass.
- Added a parent-rebuild stability case.
- `flutter analyze`: clean. Full suite: **356 passing**.