### PR TITLE
perf: make StateShared.merge linear instead of quadratic

### DIFF
--- a/lib/state/state_shared.dart
+++ b/lib/state/state_shared.dart
@@ -99,12 +99,21 @@ abstract class StateShared extends ChangeNotifier {
     required List<dynamic> toMerge,
   }) {
     List<dynamic> newData = base;
+    // Index existing entries by id once so each incoming item is matched in
+    // constant time instead of rescanning the whole list, turning the merge
+    // from O(base * toMerge) into O(base + toMerge). First occurrences win, to
+    // mirror the previous indexWhere lookup.
+    final Map<dynamic, int> indexById = {};
+    for (int i = 0; i < newData.length; i++) {
+      indexById.putIfAbsent(newData[i]['id'], () => i);
+    }
     for (final item in toMerge) {
       dynamic itemID = item['id'];
-      int itemIndex = newData.indexWhere((element) => element['id'] == itemID);
-      if (itemIndex >= 0) {
+      final int? itemIndex = indexById[itemID];
+      if (itemIndex != null) {
         newData[itemIndex] = item;
       } else {
+        indexById[itemID] = newData.length;
         newData.add(item);
       }
     }

--- a/test/state/state_shared_test.dart
+++ b/test/state/state_shared_test.dart
@@ -65,5 +65,72 @@ void main() {
       // Assert
       expect(notified, isTrue);
     });
+
+    group('merge', () {
+      test('should append entries with new ids', () {
+        // Arrange
+        final state = _TestState();
+        final base = [
+          {'id': 1, 'name': 'a'},
+        ];
+
+        // Act
+        final result = state.merge(
+          base: base,
+          toMerge: [
+            {'id': 2, 'name': 'b'},
+          ],
+        );
+
+        // Assert
+        expect(result, [
+          {'id': 1, 'name': 'a'},
+          {'id': 2, 'name': 'b'},
+        ]);
+      });
+
+      test('should replace existing entries in place by id', () {
+        // Arrange
+        final state = _TestState();
+        final base = [
+          {'id': 1, 'name': 'a'},
+          {'id': 2, 'name': 'b'},
+        ];
+
+        // Act
+        final result = state.merge(
+          base: base,
+          toMerge: [
+            {'id': 1, 'name': 'updated'},
+          ],
+        );
+
+        // Assert — same position, replaced value, no new entry
+        expect(result, [
+          {'id': 1, 'name': 'updated'},
+          {'id': 2, 'name': 'b'},
+        ]);
+      });
+
+      test('should let a later duplicate id replace an appended entry', () {
+        // Arrange — mirrors the old indexWhere behavior where a second incoming
+        // item with the same new id overwrites the first that was appended.
+        final state = _TestState();
+
+        // Act
+        final result = state.merge(
+          base: [],
+          toMerge: [
+            {'id': 5, 'name': 'first'},
+            {'id': 5, 'name': 'second'},
+          ],
+        );
+
+        // Assert
+        expect(result, [
+          {'id': 5, 'name': 'second'},
+        ]);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary

`StateShared.merge` combines paginated / streamed results by matching entries on their `id`. For **every** item in `toMerge` it called `newData.indexWhere`, rescanning the whole accumulated list — **O(base × toMerge)**. On infinite-scroll and incremental-pagination flows `base` grows with each page, so the merge cost grows quadratically as more pages load.

## Change
Build an `id -> index` map of the base list once, then resolve each incoming item in constant time, reducing the merge to **O(base + toMerge)**.

## Why it's safe (semantics preserved)
- First-occurrence indexing mirrors `indexWhere` (map uses `putIfAbsent`).
- Existing entries are still replaced **in place** at the same index.
- New ids are appended.
- A later duplicate id within the same `toMerge` still overwrites the entry appended earlier in the call (the map is updated on append).

## Tests
- Added append, in-place-replace, and duplicate-id merge cases to `state_shared_test`.
- `flutter analyze`: clean. Full suite: **359 passing**.