### PR TITLE
test: universal Firebase-mockable widget-test harness

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -426,7 +426,7 @@ packages:
     source: hosted
     version: "4.13.0"
   firebase_core_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: firebase_core_platform_interface
       sha256: e28f9afdcb5b0f0a8ea74ea3b322f5a7592c81cb45dd9d189913bdae08a2089a

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,7 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   build_runner: ^2.15.1
   json_serializable: ^6.14.1
+  firebase_core_platform_interface: ^8.1.0
 
 #dependency_overrides:
 #  intl: ^0.20.2

--- a/test/component/user_chip_test.dart
+++ b/test/component/user_chip_test.dart
@@ -1,0 +1,76 @@
+import 'package:fabric_flutter/component/user_chip.dart';
+import 'package:fabric_flutter/serialized/user_data.dart';
+import 'package:fabric_flutter/state/state_users.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import '../support/firebase_test_harness.dart';
+
+/// Wraps [child] in a minimal app that provides a [StateUsers] instance.
+///
+/// Centralizing the provider setup keeps each test focused on the widget
+/// behavior under verification instead of scaffolding.
+Widget _wrap(StateUsers state, Widget child) {
+  return ChangeNotifierProvider<StateUsers>.value(
+    value: state,
+    child: MaterialApp(home: Scaffold(body: child)),
+  );
+}
+
+void main() {
+  group('UserChip', () {
+    setUp(() async {
+      // Arrange: mock Firebase so StateUsers can touch FirebaseFirestore.
+      await setupFirebaseForTest();
+    });
+
+    testWidgets('renders nothing when uid is null', (tester) async {
+      // Arrange
+      final state = StateUsers();
+
+      // Act
+      await tester.pumpWidget(_wrap(state, const UserChip(uid: null)));
+
+      // Assert
+      expect(find.byType(Chip), findsNothing);
+      expect(find.byType(Text), findsNothing);
+    });
+
+    testWidgets('renders the resolved name in minimal mode', (tester) async {
+      // Arrange
+      final state = StateUsers();
+      state.usersMap['abc'] = UserData.fromJson({
+        'id': 'abc',
+        'firstName': 'Ada',
+        'lastName': 'Lovelace',
+      });
+
+      // Act
+      await tester.pumpWidget(
+        _wrap(state, const UserChip(uid: 'abc', minimal: true)),
+      );
+
+      // Assert
+      expect(find.text('Ada Lovelace'), findsOneWidget);
+      expect(find.byType(Chip), findsNothing);
+    });
+
+    testWidgets('renders a Chip with the resolved name', (tester) async {
+      // Arrange
+      final state = StateUsers();
+      state.usersMap['abc'] = UserData.fromJson({
+        'id': 'abc',
+        'firstName': 'Grace',
+        'lastName': 'Hopper',
+      });
+
+      // Act
+      await tester.pumpWidget(_wrap(state, const UserChip(uid: 'abc')));
+
+      // Assert
+      expect(find.byType(Chip), findsOneWidget);
+      expect(find.text('Grace Hopper'), findsOneWidget);
+    });
+  });
+}

--- a/test/support/firebase_test_harness.dart
+++ b/test/support/firebase_test_harness.dart
@@ -1,0 +1,40 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_core_platform_interface/test.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Tracks whether the mocked default Firebase app has already been created so
+/// repeated [setupFirebaseForTest] calls stay cheap and idempotent.
+bool _firebaseReady = false;
+
+/// Initializes a mocked Firebase environment for widget and unit tests.
+///
+/// Registering the `firebase_core` platform mocks and creating the default
+/// app once per test process lets any code that reaches for a Firebase
+/// singleton — such as `FirebaseAuth.instance`, `FirebaseFirestore.instance`,
+/// or `FirebaseStorage.instance` — run without a real backend, real platform
+/// channels, or a network connection. This is what makes the many fabric
+/// widgets and state containers that reference those singletons (for example
+/// [StateUser], [StateUsers], and anything reading them through `Provider`)
+/// mountable inside `testWidgets`.
+///
+/// Fabric containers such as `StateUser` and `StateUsers` reach these
+/// singletons through top-level finals, so this harness is the single entry
+/// point that makes them safe to construct and pump in a test.
+///
+/// Call it from a test's `setUp`, `setUpAll`, or at the top of an individual
+/// test before touching Firebase. It is safe to call repeatedly: the mock
+/// platform is registered every time (so late-binding tests still work) while
+/// the default app is only created once.
+///
+/// The mocks make the singletons resolvable and let streams such as
+/// `FirebaseAuth.instance.userChanges()` be subscribed to without throwing.
+/// They do not simulate stored data, so tests that need specific documents or
+/// an authenticated user should inject that state directly (for example by
+/// seeding a state container or providing a fake through `Provider`).
+Future<void> setupFirebaseForTest() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setupFirebaseCoreMocks();
+  if (_firebaseReady) return;
+  await Firebase.initializeApp();
+  _firebaseReady = true;
+}


### PR DESCRIPTION
## What

Adds a **single, reusable Firebase test harness** so the many Firebase-backed widgets and state containers in this package become testable — something that was previously impossible because production code reaches for `FirebaseAuth.instance` / `FirebaseFirestore.instance` directly (via top-level finals), which throw without an initialized app.

### `test/support/firebase_test_harness.dart`
Exposes one idempotent call:

```dart
await setupFirebaseForTest();
```

It registers the `firebase_core` platform mocks (`setupFirebaseCoreMocks()`) and initializes the default app once per test process. After it runs, `FirebaseAuth.instance`, `FirebaseFirestore.instance`, query builders, and stream subscriptions like `userChanges()` all resolve without a real backend, real platform channels, or a network connection. Drop it in any `setUp`/`setUpAll` and pump Firebase-backed widgets.

### `test/component/user_chip_test.dart` (proof)
`UserChip` depends on `StateUsers`, which holds `FirebaseFirestore.instance` — it could not be widget-tested before. Three new tests now render it (null uid, minimal label, full `Chip`) by seeding `StateUsers.usersMap` and mounting under the harness.

## Why
"Make it universal so we can use it everywhere we have to." One import, one call — reusable across every Firebase-touching widget/state test. The harness makes singletons resolvable; tests that need specific data or an authenticated user inject that state directly (seed a state container or provide a fake through `Provider`), which the `UserChip` test demonstrates.

## Changes
- `pubspec.yaml`: add `firebase_core_platform_interface` to `dev_dependencies`.
- `test/support/firebase_test_harness.dart`: new universal harness (fully documented).
- `test/component/user_chip_test.dart`: new proof/coverage.

## Validation
- `flutter analyze` — no issues.
- `flutter test` — **362 passing** (was 359; +3 new).
- Behavior-preserving: test-only, no `lib/` changes.