### PR TITLE
perf: hoist StateUsers.serialized out of UsersDropdown List.generate

### DIFF
--- a/lib/component/users_dropdown.dart
+++ b/lib/component/users_dropdown.dart
@@ -103,8 +103,9 @@ class UsersDropdown extends StatelessWidget implements PreferredSizeWidget {
     SearchController searchController = SearchController();
     final locales = AppLocalizations.of(context);
     final state = Provider.of<StateUsers>(context);
-    List<ButtonOptions> items = List.generate(state.serialized.length, (index) {
-      final item = state.serialized[index];
+    final serialized = state.serialized;
+    List<ButtonOptions> items = List.generate(serialized.length, (index) {
+      final item = serialized[index];
       String labelAlt = '';
       if (item.username != null) {
         labelAlt += item.username!;

--- a/test/component/users_dropdown_test.dart
+++ b/test/component/users_dropdown_test.dart
@@ -1,0 +1,82 @@
+import 'package:fabric_flutter/component/input_data.dart';
+import 'package:fabric_flutter/component/users_dropdown.dart';
+import 'package:fabric_flutter/helper/app_localizations_delegate.dart';
+import 'package:fabric_flutter/state/state_users.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import '../support/firebase_test_harness.dart';
+
+/// Pumps [child] with a [StateUsers] provider and loaded localization.
+///
+/// Wiring localization and Provider once keeps each test focused on the
+/// dropdown behavior rather than repeating scaffold setup.
+Future<void> _pump(WidgetTester tester, StateUsers state, Widget child) async {
+  await tester.pumpWidget(
+    ChangeNotifierProvider<StateUsers>.value(
+      value: state,
+      child: MaterialApp(
+        localizationsDelegates: const [AppLocalizationsDelegate(locales: {})],
+        supportedLocales: const [Locale('en', 'US')],
+        home: Scaffold(body: child),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  group('UsersDropdown', () {
+    setUp(() async {
+      // Arrange: mock Firebase so StateUsers can touch FirebaseFirestore.
+      await setupFirebaseForTest();
+    });
+
+    testWidgets('renders a fixed-height placeholder when there are no users', (
+      tester,
+    ) async {
+      // Arrange
+      final state = StateUsers();
+
+      // Act
+      await _pump(tester, state, const UsersDropdown(uid: null));
+
+      // Assert
+      expect(find.byType(InputData), findsNothing);
+      expect(find.byType(SizedBox), findsWidgets);
+    });
+
+    testWidgets('builds a dropdown of options from serialized users', (
+      tester,
+    ) async {
+      // Arrange
+      final state = StateUsers();
+      state.data = [
+        {'id': 'b', 'firstName': 'Bob', 'lastName': 'Stone'},
+        {'id': 'a', 'firstName': 'Ada', 'lastName': 'Byron'},
+      ];
+
+      // Act
+      await _pump(tester, state, const UsersDropdown(uid: null));
+
+      // Assert – dropdown is rendered instead of the empty placeholder.
+      expect(find.byType(InputData), findsOneWidget);
+    });
+
+    test('serialized returns users sorted by name', () {
+      // Arrange
+      final state = StateUsers();
+      state.data = [
+        {'id': 'b', 'firstName': 'Bob', 'lastName': 'Stone'},
+        {'id': 'a', 'firstName': 'Ada', 'lastName': 'Byron'},
+      ];
+
+      // Act
+      final names = state.serialized.map((user) => user.name).toList();
+
+      // Assert
+      expect(names, ['Ada Byron', 'Bob Stone']);
+    });
+  });
+}


### PR DESCRIPTION
## What
`UsersDropdown.build` called `state.serialized` inside `List.generate` — once for the length and once per index:

```dart
List<ButtonOptions> items = List.generate(state.serialized.length, (index) {
  final item = state.serialized[index];   // recomputed every iteration
```

`StateUsers.serialized` rebuilds the entire user list on **every access** (`data.map(UserData.fromJson).toList()` + `sort`). So rendering N users ran **N+1** full serialize+sort passes per build — **O(n^2 log n)**, and `limitDefault` for users is 200.

## Fix
Read `serialized` once into a local and index that. Linear build, identical ordering and output. Behavior-preserving.

## Tests
Adds `test/component/users_dropdown_test.dart` (first consumer of the new Firebase test harness from #208):
- empty placeholder when no users
- dropdown renders `InputData` when users are seeded via `StateUsers.data`
- `serialized` returns users sorted by name

## Validation
- `flutter analyze` — no issues.
- `flutter test` — **365 passing** (was 362; +3 new).
