### PR TITLE
perf: resolve current user id once in UserAdmin instead of per row

### DIFF
--- a/lib/component/user_admin.dart
+++ b/lib/component/user_admin.dart
@@ -207,6 +207,9 @@ class UserAdmin extends StatelessWidget {
     }
     final stateUser = Provider.of<StateUser>(context, listen: false);
     final state = Provider.of<StateUsers>(context, listen: false);
+    // Resolve the current user's id once; StateUser.serialized rebuilds a
+    // UserData on every access, so avoid recomputing it per row.
+    final currentUserId = stateUser.serialized.id;
 
     // Set default limit when you will use shrinkWrap
     if (!primary) state.limitDefault = 100;
@@ -294,7 +297,7 @@ class UserAdmin extends StatelessWidget {
     /// Disables editing when the selected [user] matches the current
     /// [StateUser.serialized] identity or when [disabled] is `true`.
     showUpdateDialog(UserData user) {
-      bool sameUser = stateUser.serialized.id == user.id;
+      bool sameUser = currentUserId == user.id;
       // Don't allow a user to change anything about itself on the 'admin' view
       bool canUpdateUser = !sameUser;
       if (disabled) canUpdateUser = false;
@@ -351,7 +354,7 @@ class UserAdmin extends StatelessWidget {
         final userData = data as Map<String, dynamic>;
         final user = UserData.fromJson(userData);
         assert(user.id != null, 'user id is required');
-        bool sameUser = stateUser.serialized.id == user.id;
+        bool sameUser = currentUserId == user.id;
         // Don't allow a user to change anything about itself on the 'admin' view
         bool canUpdateUser = !sameUser;
         if (disabled) canUpdateUser = false;

--- a/test/state/state_user_test.dart
+++ b/test/state/state_user_test.dart
@@ -1,0 +1,37 @@
+import 'package:fabric_flutter/state/state_user.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../support/firebase_test_harness.dart';
+
+void main() {
+  group('StateUser', () {
+    setUp(() async {
+      // Arrange: mock Firebase so StateUser singletons resolve.
+      await setupFirebaseForTest();
+    });
+
+    test('serialized reflects the id stored in data', () {
+      // Arrange
+      final state = StateUser();
+
+      // Act
+      state.data = {'id': 'user-123', 'firstName': 'Ada'};
+
+      // Assert
+      expect(state.serialized.id, 'user-123');
+      expect(state.serialized.firstName, 'Ada');
+    });
+
+    test('serialized returns an empty user when data is null', () {
+      // Arrange
+      final state = StateUser();
+
+      // Act
+      final user = state.serialized;
+
+      // Assert
+      expect(user.id, isNull);
+      expect(user.firstName, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## What
`UserAdmin.build` read `stateUser.serialized.id` inside the `PaginationContainer` `itemBuilder` (and the update-dialog closure):

```dart
itemBuilder: (c, index, data) {
  ...
  bool sameUser = stateUser.serialized.id == user.id;   // per row
```

`StateUser.serialized` rebuilds a `UserData` via `UserData.fromJson(data)` on **every access**, so each rendered/scrolled row allocated a fresh current-user model just to read one id.

## Fix
Resolve the id once before the builder and compare against the local:

```dart
final currentUserId = stateUser.serialized.id;
...
bool sameUser = currentUserId == user.id;
```

Identical self-edit guard, one allocation per build instead of one per row. Behavior-preserving.

## Tests
Adds `test/state/state_user_test.dart` (using the #208 Firebase harness):
- `serialized.id`/`firstName` reflect assigned `data`
- empty-data fallback returns a null id

## Validation
- `flutter analyze` — no issues.
- `flutter test` — **367 passing** (was 365; +2 new).
