### PR TITLE
perf: read StateUser.serialized once per build in ProfileEdit

### DIFF
--- a/lib/component/profile_edit.dart
+++ b/lib/component/profile_edit.dart
@@ -173,12 +173,13 @@ class _ProfileEditState extends State<ProfileEdit> {
   Widget build(BuildContext context) {
     final locales = AppLocalizations.of(context);
     final stateUser = Provider.of<StateUser>(context, listen: false);
-    userImage = widget.prefix != null && stateUser.serialized.avatar != null
-        ? '${widget.prefix}/${stateUser.serialized.avatar}'
-        : stateUser.serialized.avatar;
+    final user = stateUser.serialized;
+    userImage = widget.prefix != null && user.avatar != null
+        ? '${widget.prefix}/${user.avatar}'
+        : user.avatar;
     if (!changed) {
-      nameFirst = nameFirst ?? stateUser.serialized.firstName;
-      nameLast = nameLast ?? stateUser.serialized.lastName;
+      nameFirst = nameFirst ?? user.firstName;
+      nameLast = nameLast ?? user.lastName;
     }
 
     /// Refreshes the avatar preview using staged bytes or persisted user data.


### PR DESCRIPTION
## What
`ProfileEdit.build` accessed `stateUser.serialized` up to four times per build:

```dart
userImage = widget.prefix != null && stateUser.serialized.avatar != null
    ? '${widget.prefix}/${stateUser.serialized.avatar}'
    : stateUser.serialized.avatar;
if (!changed) {
  nameFirst = nameFirst ?? stateUser.serialized.firstName;
  nameLast = nameLast ?? stateUser.serialized.lastName;
}
```

`StateUser.serialized` rebuilds a `UserData` via `UserData.fromJson(data)` on **every access**, so each build allocated several throwaway models.

## Fix
Read it once and reuse:

```dart
final user = stateUser.serialized;
userImage = widget.prefix != null && user.avatar != null
    ? '${widget.prefix}/${user.avatar}'
    : user.avatar;
if (!changed) {
  nameFirst = nameFirst ?? user.firstName;
  nameLast = nameLast ?? user.lastName;
}
```

The per-keystroke `onChanged` callbacks intentionally keep reading live `stateUser.serialized`, so behavior is identical.

## Validation
- `flutter analyze` — no issues.
- `flutter test` — **367 passing**, unchanged (pure hoist, identical output).
