### PR TITLE
perf: hoist ExpansionTable column widths out of the per-row builder

### DIFF
--- a/lib/component/expansion_table.dart
+++ b/lib/component/expansion_table.dart
@@ -189,6 +189,7 @@ class _ExpansionTableState extends State<ExpansionTable> {
       data.header!.length,
       const FixedColumnWidth(300.0),
     );
+    final Map<int, TableColumnWidth> tableColumnWidths = tableColumns.asMap();
     final double effectiveHorizontalMargin =
         widget.horizontalMargin ?? theme.dataTableTheme.horizontalMargin ?? 0;
     final double effectiveColumnSpacing =
@@ -389,7 +390,7 @@ class _ExpansionTableState extends State<ExpansionTable> {
               ),
               child: Table(
                 defaultVerticalAlignment: TableCellVerticalAlignment.middle,
-                columnWidths: tableColumns.asMap(),
+                columnWidths: tableColumnWidths,
                 children: [TableRow(children: cellsBase)],
               ),
             ),
@@ -436,7 +437,7 @@ class _ExpansionTableState extends State<ExpansionTable> {
             height: headingRowHeight,
             child: Table(
               defaultVerticalAlignment: TableCellVerticalAlignment.middle,
-              columnWidths: tableColumns.asMap(),
+              columnWidths: tableColumnWidths,
               children: [TableRow(children: columnsList)],
             ),
           ),


### PR DESCRIPTION
## What
`ExpansionTable`'s `getRows` builds a `Table` for every row with:

```dart
columnWidths: tableColumns.asMap(),
```

`getRows` runs once per row (and the header `Table` repeats the same call), yet `tableColumns` is a fixed `List<TableColumnWidth>` built once per build that never changes. So each rendered row allocated an identical throwaway `Map<int, TableColumnWidth>` view.

## Fix
Compute the map once and reuse it for the header and every row:

```dart
final Map<int, TableColumnWidth> tableColumnWidths = tableColumns.asMap();
...
columnWidths: tableColumnWidths,
```

Identical column sizing, one map allocation per build instead of one per row.

## Tests
Existing `test/component/expansion_table_test.dart` already exercises the affected paths — multi-row rendering, nested child expansion, and disposal — and stays green.

## Validation
- `flutter analyze` — no issues.
- `flutter test` — **367 passing**, unchanged (behavior-preserving hoist).
