### PR TITLE
perf: hoist LogsList text styles out of the per-entry builder

### DIFF
--- a/lib/component/logs_list.dart
+++ b/lib/component/logs_list.dart
@@ -78,19 +78,20 @@ class LogsList extends StatelessWidget {
     Widget container = const SizedBox(height: 0);
     if (logs == null || logs!.isEmpty) return container;
 
+    final TextStyle? textThemeBase = textTheme.bodyLarge?.copyWith(
+      height: !minimal ? 1.7 : null,
+    );
+    final TextStyle? textThemeColor = textThemeBase?.copyWith(
+      color: highlightColor ?? textThemeBase.color ?? Colors.black,
+      fontWeight: FontWeight.w600,
+    );
+
     Widget getItem(LogsData item) {
       DateTime? timestamp = item.timestamp ?? DateTime.now();
       String? text = item.text?.isNotEmpty == true ? item.text : null;
       if (text == null || text.isEmpty) return container;
       List<InlineSpan> textFormatted = [];
       int? initialPosition = 0;
-      TextStyle? textThemeBase = textTheme.bodyLarge?.copyWith(
-        height: !minimal ? 1.7 : null,
-      );
-      TextStyle? textThemeColor = textThemeBase?.copyWith(
-        color: highlightColor ?? textThemeBase.color ?? Colors.black,
-        fontWeight: FontWeight.w600,
-      );
       Iterable matches = _placeholderExp.allMatches(text);
       final timestampWidget = Padding(
         padding: const EdgeInsets.only(bottom: 4.0),


### PR DESCRIPTION
## What
`LogsList`'s per-entry `getItem` derived two `TextStyle` values for every log row:

```dart
Widget getItem(LogsData item) {
  ...
  TextStyle? textThemeBase = textTheme.bodyLarge?.copyWith(
    height: !minimal ? 1.7 : null,
  );
  TextStyle? textThemeColor = textThemeBase?.copyWith(
    color: highlightColor ?? textThemeBase.color ?? Colors.black,
    fontWeight: FontWeight.w600,
  );
```

Both depend only on `textTheme`, `minimal`, and `highlightColor` — all constant across the list — so rendering N logs rebuilt the same two styles N times (2 `copyWith` allocations per row).

## Fix
Compute both styles once in `build` and reuse them for every entry. Identical output.

## Tests
Existing `test/component/logs_list_test.dart` covers the empty state, brace-highlighted spans (which use `textThemeColor`), and timestamp formatting — all green.

## Validation
- `flutter analyze` — no issues.
- `flutter test` — **367 passing**, unchanged (behavior-preserving hoist).
