### PR TITLE
perf: hoist invariant search term out of dropdown filter loops

### DIFF
--- a/lib/component/filter_menu.dart
+++ b/lib/component/filter_menu.dart
@@ -1013,9 +1013,10 @@ class _FilterMenuState extends State<FilterMenu> {
             final value = controller.text;
             List<FilterData> recommendations = pendingOptions;
             if (value.isNotEmpty) {
+              final valueLower = value.toLowerCase();
               recommendations = recommendations.where((element) {
                 final labelMatch = element.label.toLowerCase().contains(
-                  value.toLowerCase(),
+                  valueLower,
                 );
                 final valueMatch = element.value.toString().contains(value);
                 return labelMatch || valueMatch;

--- a/lib/component/input_data.dart
+++ b/lib/component/input_data.dart
@@ -1406,6 +1406,14 @@ getValue -------------------------------------
               // keep @, . and + characters for more flexible searches (eg. emails, phone prefixes)
               final regex = _searchSanitizeExp;
               if (value.isNotEmpty) {
+                // The sanitized search term does not depend on the element, so
+                // compute it once instead of per candidate on every keystroke.
+                final valueClean = GSM
+                    .toGSM(value)
+                    .toLowerCase()
+                    .replaceAll(regex, '')
+                    .trim();
+                final valueLower = value.toLowerCase();
                 recommendations = recommendations.where((element) {
                   // Remove special characters and spaces from the label to make search more flexible.
                   final labelClean = GSM
@@ -1420,14 +1428,9 @@ getValue -------------------------------------
                             .replaceAll(regex, '')
                             .trim()
                       : null;
-                  final valueClean = GSM
-                      .toGSM(value)
-                      .toLowerCase()
-                      .replaceAll(regex, '')
-                      .trim();
                   final labelMatch = labelClean.contains(valueClean);
                   final labelAltMatch =
-                      labelAltClean?.contains(value.toLowerCase()) ?? false;
+                      labelAltClean?.contains(valueLower) ?? false;
                   final valueMatch = element.value.toString().contains(value);
                   return labelMatch || valueMatch || labelAltMatch;
                 }).toList();


### PR DESCRIPTION
## What
`InputData`'s dropdown `suggestionsBuilder` runs on **every keystroke** and filters the option list. Inside the `.where` closure it recomputed the sanitized **search term** for each candidate:

```dart
recommendations.where((element) {
  final labelClean = GSM.toGSM(element.label)...;      // depends on element ✓
  final valueClean = GSM.toGSM(value)                  // depends only on the query ✗
      .toLowerCase().replaceAll(regex, '').trim();
  ...
});
```

`GSM.toGSM` does real Unicode normalization, so filtering N options (up to ~200) redid the same conversion N times per keystroke.

## Fix
Compute `valueClean` (and `valueLower`) once before `.where()` and reuse them. Applied the same one-line hoist to `FilterMenu`'s suggestions filter (`value.toLowerCase()`). Match results are identical.

## Validation
- `flutter analyze` — no issues.
- `flutter test` — **367 passing**, unchanged (behavior-preserving).
