### PR TITLE
perf: build GSM.toGSM output with a StringBuffer

### DIFF
--- a/lib/helper/gsm.dart
+++ b/lib/helper/gsm.dart
@@ -633,13 +633,15 @@ class GSM {
   /// blank lines are normalized so downstream SMS services receive cleaner text.
   static String toGSM(String? content) {
     if (content == null) return '';
-    String newContent = '';
+    final StringBuffer buffer = StringBuffer();
     for (int i = 0; i < content.length; i++) {
-      String character = content[i];
-      int charcode = character.codeUnitAt(0); // Define Char Code for letter.
-      String newCharacter = charMapToReplace[charcode]?['replace'] ?? character;
-      newContent += newCharacter;
+      final String character = content[i];
+      final int charcode = character.codeUnitAt(
+        0,
+      ); // Define Char Code for letter.
+      buffer.write(charMapToReplace[charcode]?['replace'] ?? character);
     }
+    String newContent = buffer.toString();
 
     /// 1. Remove U+2069 and formatting characters, BUT keep line breaks (\n)
     /// We use a "lookahead" or specific exclusion to ensure \n and \r survive

--- a/test/helper/gsm_test.dart
+++ b/test/helper/gsm_test.dart
@@ -154,5 +154,18 @@ void main() {
         expect(result, 'a\nb');
       },
     );
+
+    test('should preserve long content unchanged after the buffered rewrite', () {
+      // Arrange – a long GSM-safe string exercises the character loop at scale.
+      final input = 'abc 123 ' * 500;
+      final expected = ('abc 123 ' * 500).trim();
+
+      // Act
+      final result = GSM.toGSM(input);
+
+      // Assert
+      expect(result, expected);
+      expect(result.length, expected.length);
+    });
   });
 }


### PR DESCRIPTION
## What
`GSM.toGSM` assembled its result with string concatenation inside a per-character loop:

```dart
String newContent = '';
for (int i = 0; i < content.length; i++) {
  String character = content[i];
  int charcode = character.codeUnitAt(0);
  String newCharacter = charMapToReplace[charcode]?['replace'] ?? character;
  newContent += newCharacter;   // reallocates + copies the whole string each step
}
```

Dart strings are immutable, so every `+=` copies the entire accumulated string — making the rewrite **O(n²)** in the content length. `toGSM` runs on hot paths (per dropdown option on every keystroke via the search filter, and SMS length calculation), so long inputs were disproportionately expensive.

## Fix
Accumulate into a `StringBuffer` and convert once — linear pass, byte-for-byte identical output:

```dart
final StringBuffer buffer = StringBuffer();
for (int i = 0; i < content.length; i++) {
  final String character = content[i];
  final int charcode = character.codeUnitAt(0);
  buffer.write(charMapToReplace[charcode]?['replace'] ?? character);
}
String newContent = buffer.toString();
```

The bounded per-part concatenation in `GSM.info` (resets every ~153 chars) is already effectively linear and left unchanged.

## Tests
Adds a long-content case to `test/helper/gsm_test.dart` guarding the buffered rewrite; the existing 7 `toGSM` cases still pass.

## Validation
- `flutter analyze` — no issues.
- `flutter test` — **368 passing** (was 367; +1 new).
