### PR TITLE
perf: build Country/Language picker options once in initState

### DIFF
--- a/lib/component/country_picker.dart
+++ b/lib/component/country_picker.dart
@@ -13,7 +13,7 @@ import 'input_data.dart';
 /// filtering. When [phoneNumberOrigin] is `true`, it limits choices to entries
 /// supported by the phone helper dataset so downstream phone-origin workflows
 /// only receive compatible values.
-class CountryPicker extends StatelessWidget {
+class CountryPicker extends StatefulWidget {
   /// Creates a country picker backed by ISO alpha-2 country codes.
   ///
   /// The picker defaults to `'US'` and forwards selection changes through
@@ -65,23 +65,33 @@ class CountryPicker extends StatelessWidget {
   /// [ISOCountries.phoneSupportedCountries] before building the dropdown.
   final bool phoneNumberOrigin;
 
-  /// Builds the localized dropdown used to select a country.
-  ///
-  /// The widget resolves labels through [BuildContext], converts each
-  /// [ISOCountry] into a [ButtonOptions] entry, and forwards changes to
-  /// [onChange].
+  /// Creates the mutable state that memoizes the country options.
   @override
-  Widget build(BuildContext context) {
-    final locales = AppLocalizations.of(context);
+  State<CountryPicker> createState() => _CountryPickerState();
+}
+
+/// Holds the pre-built dropdown options for [CountryPicker].
+///
+/// The option list is derived from the bundled ISO dataset once in
+/// [initState] instead of on every build, because it depends only on the
+/// immutable [CountryPicker.phoneNumberOrigin] flag.
+class _CountryPickerState extends State<CountryPicker> {
+  /// Caches the dropdown options built from the ISO country dataset.
+  late final List<ButtonOptions> _options;
+
+  /// Builds the country options once from the bundled ISO dataset.
+  @override
+  void initState() {
+    super.initState();
     List<ISOCountry> items = ISOCountries.countries;
-    if (phoneNumberOrigin) {
-      // Filter available voices by those available on WaveNet
+    if (widget.phoneNumberOrigin) {
+      // Filter available countries by those supported for phone origins.
       items = items.where((element) {
         return ISOCountries.phoneSupportedCountries.contains(element.alpha2);
       }).toList();
     }
     // List of iso's corresponding to the text widgets
-    List<ButtonOptions> options = List.generate(items.length, (index) {
+    _options = List.generate(items.length, (index) {
       final item = items[index];
       return ButtonOptions(
         label: '${item.flag} ${item.name} (${item.alpha2})',
@@ -89,20 +99,29 @@ class CountryPicker extends StatelessWidget {
         value: item.alpha2,
       );
     });
+  }
+
+  /// Builds the localized dropdown used to select a country.
+  ///
+  /// The widget resolves labels through [BuildContext] and forwards changes to
+  /// [CountryPicker.onChange] using the pre-built [_options].
+  @override
+  Widget build(BuildContext context) {
+    final locales = AppLocalizations.of(context);
     return InputData(
       autofillHints: const [],
       prefixIcon: const Icon(Icons.flag),
-      label: label ?? locales.get('label--country'),
+      label: widget.label ?? locales.get('label--country'),
       hintText:
-          hintText ??
+          widget.hintText ??
           locales.get('label--choose-label', {
             'label': locales.get('label--country'),
           }),
-      value: value,
+      value: widget.value,
       type: InputDataType.dropdown,
-      options: options,
-      onChanged: (dynamic value) => onChange(value as String?),
-      disabled: disabled,
+      options: _options,
+      onChanged: (dynamic value) => widget.onChange(value as String?),
+      disabled: widget.disabled,
     );
   }
 }

--- a/lib/component/language_picker.dart
+++ b/lib/component/language_picker.dart
@@ -22,7 +22,7 @@ import 'input_data.dart';
 ///   },
 /// );
 /// ```
-class LanguagePicker extends StatelessWidget {
+class LanguagePicker extends StatefulWidget {
   /// Creates a language picker wired to the shared [InputData] dropdown UI.
   ///
   /// The picker keeps widget code focused on storing the selected ISO code while
@@ -74,22 +74,33 @@ class LanguagePicker extends StatelessWidget {
   /// readable in review-only states.
   final bool disabled;
 
-  /// Builds the localized dropdown and keeps the option list in sync with [voice].
-  ///
-  /// The widget converts each [ISOLanguage] entry into a [ButtonOptions] item so
-  /// [InputData] can render a localized dropdown with consistent package styling.
+  /// Creates the mutable state that memoizes the language options.
   @override
-  Widget build(BuildContext context) {
-    final locales = AppLocalizations.of(context);
+  State<LanguagePicker> createState() => _LanguagePickerState();
+}
+
+/// Holds the pre-built dropdown options for [LanguagePicker].
+///
+/// The option list is derived from the bundled ISO dataset once in
+/// [initState] instead of on every build, because it depends only on the
+/// immutable [LanguagePicker.voice] flag.
+class _LanguagePickerState extends State<LanguagePicker> {
+  /// Caches the dropdown options built from the ISO language dataset.
+  late final List<ButtonOptions> _options;
+
+  /// Builds the language options once from the bundled ISO dataset.
+  @override
+  void initState() {
+    super.initState();
     List<ISOLanguage> items = ISOLanguages.languages;
-    if (voice) {
+    if (widget.voice) {
       // Filter available voices by those available on WaveNet
       items = items.where((element) {
         return ISOLanguages.waveNetLanguages.contains(element.alpha2);
       }).toList();
     }
     // List of iso's corresponding to the text widgets
-    List<ButtonOptions> options = List.generate(items.length, (index) {
+    _options = List.generate(items.length, (index) {
       final item = items[index];
       return ButtonOptions(
         label: '${item.emoji} ${item.name} (${item.alpha2})',
@@ -97,19 +108,28 @@ class LanguagePicker extends StatelessWidget {
         value: item.alpha2,
       );
     });
+  }
+
+  /// Builds the localized dropdown using the pre-built [_options].
+  ///
+  /// The widget forwards changes to [LanguagePicker.onChange] while resolving
+  /// labels through [BuildContext].
+  @override
+  Widget build(BuildContext context) {
+    final locales = AppLocalizations.of(context);
     return InputData(
       prefixIcon: const Icon(Icons.language),
-      label: label ?? locales.get('label--language'),
+      label: widget.label ?? locales.get('label--language'),
       hintText:
-          hintText ??
+          widget.hintText ??
           locales.get('label--choose-label', {
             'label': locales.get('label--language'),
           }),
-      value: value,
+      value: widget.value,
       type: InputDataType.dropdown,
-      options: options,
-      onChanged: (dynamic value) => onChange(value as String?),
-      disabled: disabled,
+      options: _options,
+      onChanged: (dynamic value) => widget.onChange(value as String?),
+      disabled: widget.disabled,
     );
   }
 }

--- a/test/component/country_picker_test.dart
+++ b/test/component/country_picker_test.dart
@@ -1,0 +1,53 @@
+import 'package:fabric_flutter/component/country_picker.dart';
+import 'package:fabric_flutter/component/input_data.dart';
+import 'package:fabric_flutter/helper/app_localizations_delegate.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pumps [child] with a loaded localization delegate so dropdown labels
+/// resolve to their bundled strings.
+Future<void> _pump(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: const [AppLocalizationsDelegate(locales: {})],
+      supportedLocales: const [Locale('en', 'US')],
+      home: Scaffold(body: child),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('CountryPicker', () {
+    testWidgets('renders an InputData dropdown showing the selected country', (
+      tester,
+    ) async {
+      // Arrange & Act
+      await _pump(
+        tester,
+        CountryPicker(value: 'US', onChange: (_) {}),
+      );
+
+      // Assert – the resolved label ends with the selected alpha-2 code.
+      expect(find.byType(InputData), findsOneWidget);
+      expect(find.textContaining('(US)'), findsOneWidget);
+    });
+
+    testWidgets('honors phoneNumberOrigin without throwing', (tester) async {
+      // Arrange & Act
+      await _pump(
+        tester,
+        CountryPicker(
+          value: 'US',
+          phoneNumberOrigin: true,
+          onChange: (_) {},
+        ),
+      );
+
+      // Assert
+      expect(tester.takeException(), isNull);
+      expect(find.byType(InputData), findsOneWidget);
+      expect(find.textContaining('(US)'), findsOneWidget);
+    });
+  });
+}

--- a/test/component/language_picker_test.dart
+++ b/test/component/language_picker_test.dart
@@ -1,0 +1,49 @@
+import 'package:fabric_flutter/component/input_data.dart';
+import 'package:fabric_flutter/component/language_picker.dart';
+import 'package:fabric_flutter/helper/app_localizations_delegate.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pumps [child] with a loaded localization delegate so dropdown labels
+/// resolve to their bundled strings.
+Future<void> _pump(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: const [AppLocalizationsDelegate(locales: {})],
+      supportedLocales: const [Locale('en', 'US')],
+      home: Scaffold(body: child),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('LanguagePicker', () {
+    testWidgets('renders an InputData dropdown showing the selected language', (
+      tester,
+    ) async {
+      // Arrange & Act
+      await _pump(
+        tester,
+        LanguagePicker(value: 'en', onChange: (_) {}),
+      );
+
+      // Assert – the resolved label ends with the selected alpha-2 code.
+      expect(find.byType(InputData), findsOneWidget);
+      expect(find.textContaining('(en)'), findsOneWidget);
+    });
+
+    testWidgets('honors the voice filter without throwing', (tester) async {
+      // Arrange & Act
+      await _pump(
+        tester,
+        LanguagePicker(value: 'en', voice: true, onChange: (_) {}),
+      );
+
+      // Assert
+      expect(tester.takeException(), isNull);
+      expect(find.byType(InputData), findsOneWidget);
+      expect(find.textContaining('(en)'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## What
`CountryPicker` and `LanguagePicker` were `StatelessWidget`s that rebuilt their entire option list on **every build**:

```dart
Widget build(BuildContext context) {
  List<ISOCountry> items = ISOCountries.countries; // re-deserializes ~240 models from raw JSON
  if (phoneNumberOrigin) items = items.where(...).toList();
  List<ButtonOptions> options = List.generate(items.length, ...); // ~240 allocations
  return InputData(... options: options ...);
}
```

`ISOCountries.countries` / `ISOLanguages.languages` build fresh typed models from the raw dataset on each access, so every rebuild redid ~240 country (or ~180 language) `fromJson` calls plus a full `ButtonOptions` regeneration.

## Fix
The option list depends only on the immutable `phoneNumberOrigin` / `voice` flag, so convert each picker to a `StatefulWidget` and build the options **once in `initState`**. Rebuilds now just re-read the cached list. Selection, filtering, and labels are unchanged (mirrors the PhoneInput approach in #206).

### Why not cache at the source instead?
`PhoneInput` mutates the `ISOCountry` instances returned by `ISOCountries.countries` (`items[index].name = ...`), so the getter must keep returning fresh models — memoizing shared instances there would corrupt state. The per-widget cache captures immutable strings into `ButtonOptions`, avoiding that hazard.

## Tests
Adds `country_picker_test.dart` and `language_picker_test.dart` covering the default selection and the filtered (`phoneNumberOrigin` / `voice`) variant.

## Validation
- `flutter analyze` — no issues.
- `flutter test` — **372 passing** (was 368; +4 new).
