### PR TITLE
perf: memoize StateUsers.serialized against the data reference

### DIFF
--- a/lib/state/state_users.dart
+++ b/lib/state/state_users.dart
@@ -21,18 +21,39 @@ class StateUsers extends StateCollection {
   @override
   int get limitDefault => 200;
 
+  /// Caches the last serialized result together with the [data] reference it
+  /// was built from.
+  ///
+  /// [serialized] deserializes and sorts the entire user list, and it is read
+  /// repeatedly per update (once inside [notifyListeners] plus once per widget
+  /// build). Because [data] is replaced by a new object on every fetch, an
+  /// identity check lets repeated reads of the same data reuse the previous
+  /// result instead of redoing N `fromJson` calls and a full sort each time.
+  List<UserData>? _serializedCache;
+
+  /// Holds the [data] reference that produced [_serializedCache].
+  Object? _serializedCacheToken;
+
   /// Returns the current query results as sorted [UserData] objects.
   ///
   /// Sorting by [UserData.name] keeps user pickers stable even when Firestore
-  /// returns documents in a different order.
+  /// returns documents in a different order. The result is memoized against the
+  /// current [data] reference so repeated reads within the same update are free.
   @override
   List<UserData> get serialized {
-    if (data == null) return [];
+    final currentData = data;
+    if (currentData == null) return [];
+    if (_serializedCache != null &&
+        identical(_serializedCacheToken, currentData)) {
+      return _serializedCache!;
+    }
     try {
-      List<UserData> items = (data as List<dynamic>)
+      List<UserData> items = (currentData as List<dynamic>)
           .map((value) => UserData.fromJson(value))
           .toList();
       items.sort((a, b) => a.name.compareTo(b.name));
+      _serializedCache = items;
+      _serializedCacheToken = currentData;
       return items;
     } catch (e) {
       error = serializationError(e);

--- a/test/state/state_users_test.dart
+++ b/test/state/state_users_test.dart
@@ -1,0 +1,73 @@
+import 'package:fabric_flutter/state/state_users.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../support/firebase_test_harness.dart';
+
+void main() {
+  group('StateUsers', () {
+    setUp(() async {
+      // Arrange: mock Firebase so the Firestore instance resolves.
+      await setupFirebaseForTest();
+    });
+
+    test('serialized sorts users by name', () {
+      // Arrange
+      final state = StateUsers();
+
+      // Act
+      state.data = [
+        {'id': 'b', 'firstName': 'Zoe'},
+        {'id': 'a', 'firstName': 'Ada'},
+      ];
+
+      // Assert
+      final serialized = state.serialized;
+      expect(serialized.map((user) => user.id).toList(), ['a', 'b']);
+    });
+
+    test('serialized reuses the cached list for the same data reference', () {
+      // Arrange
+      final state = StateUsers();
+      state.data = [
+        {'id': 'a', 'firstName': 'Ada'},
+      ];
+
+      // Act
+      final first = state.serialized;
+      final second = state.serialized;
+
+      // Assert: identical instance means no re-deserialize/re-sort occurred.
+      expect(identical(first, second), isTrue);
+    });
+
+    test('serialized rebuilds when data is replaced', () {
+      // Arrange
+      final state = StateUsers();
+      state.data = [
+        {'id': 'a', 'firstName': 'Ada'},
+      ];
+      final first = state.serialized;
+
+      // Act
+      state.data = [
+        {'id': 'c', 'firstName': 'Cara'},
+      ];
+      final second = state.serialized;
+
+      // Assert
+      expect(identical(first, second), isFalse);
+      expect(second.single.id, 'c');
+    });
+
+    test('serialized returns an empty list when data is null', () {
+      // Arrange
+      final state = StateUsers();
+
+      // Act
+      final serialized = state.serialized;
+
+      // Assert
+      expect(serialized, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## What
`StateUsers.serialized` rebuilt the entire user list on **every access**:

```dart
List<UserData> get serialized {
  if (data == null) return [];
  List<UserData> items = (data as List)
      .map((value) => UserData.fromJson(value)) // N fromJson calls
      .toList();
  items.sort((a, b) => a.name.compareTo(b.name)); // full sort
  return items;
}
```

It is read repeatedly per update — once inside `notifyListeners()` (which seeds `_usersMap`) and again on **every widget build** that watches the notifier (user pickers, `UsersDropdown`, participant lists). So a single Firestore update could redo the N `fromJson` calls plus a full sort several times.

## Fix
`data` is replaced by a **new object** on each fetch (`StateShared.set data`), so cache the serialized result alongside the `data` reference it was built from and reuse it while that reference is unchanged. Replacing `data` invalidates the cache automatically via an `identical(...)` check. Sort order and output are unchanged.

## Tests
Adds `state_users_test.dart` covering:
- sort-by-name order,
- cache reuse for the same `data` reference (identical list instance),
- cache invalidation when `data` is replaced,
- the null-data path returning an empty list.

## Validation
- `flutter analyze` — no issues.
- `flutter test` — **376 passing** (was 372; +4 new).
