### PR TITLE
perf: memoize StateUser.serialized against the data reference

### DIFF
--- a/lib/state/state_user.dart
+++ b/lib/state/state_user.dart
@@ -112,11 +112,35 @@ class StateUser extends StateDocument {
 
   Map<String, dynamic> get claims => _claims ?? {};
 
+  /// Caches the last serialized user together with the [data] reference it was
+  /// built from.
+  ///
+  /// [serialized] is read many times per update — `role` reads it twice,
+  /// `admin`/`id`/`signedIn` route through it, and every widget that watches
+  /// this notifier reads it on build. Because [data] is replaced by a new map
+  /// on each update (never mutated in place), an identity check lets repeated
+  /// reads of the same data reuse the previous [UserData] instead of rebuilding
+  /// it with [UserData.fromJson] each time.
+  UserData? _serializedCache;
+
+  /// Holds the [data] reference that produced [_serializedCache].
+  Object? _serializedCacheToken;
+
+  /// Tracks whether [_serializedCache] holds a computed value yet.
+  bool _serializedCached = false;
+
   /// Returns serialized data [UserData]
   @override
   UserData get serialized {
+    final currentData = data;
+    if (_serializedCached && identical(_serializedCacheToken, currentData)) {
+      return _serializedCache!;
+    }
     try {
-      UserData userDataSerialized = UserData.fromJson(data ?? {});
+      final userDataSerialized = UserData.fromJson(currentData ?? {});
+      _serializedCache = userDataSerialized;
+      _serializedCacheToken = currentData;
+      _serializedCached = true;
       return userDataSerialized;
     } catch (e) {
       error = serializationError(e);

--- a/test/state/state_user_test.dart
+++ b/test/state/state_user_test.dart
@@ -33,5 +33,33 @@ void main() {
       expect(user.id, isNull);
       expect(user.firstName, isNull);
     });
+
+    test('serialized reuses the cached instance for the same data', () {
+      // Arrange
+      final state = StateUser();
+      state.data = {'id': 'user-123', 'firstName': 'Ada'};
+
+      // Act
+      final first = state.serialized;
+      final second = state.serialized;
+
+      // Assert: identical instance means no rebuild via fromJson occurred.
+      expect(identical(first, second), isTrue);
+    });
+
+    test('serialized rebuilds when data is replaced', () {
+      // Arrange
+      final state = StateUser();
+      state.data = {'id': 'user-123', 'firstName': 'Ada'};
+      final first = state.serialized;
+
+      // Act
+      state.data = {'id': 'user-456', 'firstName': 'Grace'};
+      final second = state.serialized;
+
+      // Assert
+      expect(identical(first, second), isFalse);
+      expect(second.id, 'user-456');
+    });
   });
 }


### PR DESCRIPTION
## What
`StateUser.serialized` rebuilt a `UserData` on **every access**:

```dart
UserData get serialized {
  UserData userDataSerialized = UserData.fromJson(data ?? {}); // rebuild each call
  return userDataSerialized;
}
```

It is one of the hottest getters in the package. It's read many times per update:
- `role` reads `serialized` **twice**,
- `admin`, `id`, `signedIn` all route through it,
- every widget watching `StateUser` reads it on build.

`UserData.fromJson` also recomputes the display name from its parts, so each of those reads repeated the full deserialize.

## Fix
`StateDocument` replaces `data` with a **fresh map** on each snapshot (never mutating in place, per PR #217's analysis), so cache the serialized `UserData` alongside the `data` reference it was built from and reuse it while that reference is unchanged. Replacing `data` invalidates the cache via an `identical(...)` check. Output is unchanged.

## Tests
Extends `state_user_test.dart` with:
- cache reuse for the same `data` (identical instance),
- cache invalidation when `data` is replaced.

## Validation
- `flutter analyze` — no issues.
- `flutter test` — **378 passing** (was 376; +2 new).
