### PR TITLE
perf: stop allocating a leaked SearchController per UsersDropdown build

### DIFF
--- a/lib/component/users_dropdown.dart
+++ b/lib/component/users_dropdown.dart
@@ -100,7 +100,6 @@ class UsersDropdown extends StatelessWidget implements PreferredSizeWidget {
   /// layouts remain stable while asynchronous state is still resolving.
   @override
   Widget build(BuildContext context) {
-    SearchController searchController = SearchController();
     final locales = AppLocalizations.of(context);
     final state = Provider.of<StateUsers>(context);
     final serialized = state.serialized;
@@ -158,7 +157,6 @@ class UsersDropdown extends StatelessWidget implements PreferredSizeWidget {
       constraints: BoxConstraints(minHeight: kToolbarHeight),
       padding: padding,
       child: InputData(
-        searchController: searchController,
         key: const Key('users-dropdown'),
         label: locales.get(label ?? 'label--search'),
         prefixIcon: Icon(icon ?? Icons.search),

--- a/test/component/users_dropdown_test.dart
+++ b/test/component/users_dropdown_test.dart
@@ -78,5 +78,25 @@ void main() {
       // Assert
       expect(names, ['Ada Byron', 'Bob Stone']);
     });
+
+    testWidgets(
+      'keeps rendering across rebuilds without leaking a controller',
+      (tester) async {
+        // Arrange
+        final state = StateUsers();
+        state.data = [
+          {'id': 'a', 'firstName': 'Ada', 'lastName': 'Byron'},
+        ];
+
+        // Act: pump, then force additional rebuilds of the same widget tree.
+        await _pump(tester, state, const UsersDropdown(uid: null));
+        await tester.pump();
+        await tester.pump();
+
+        // Assert: still renders a single dropdown, no exceptions on rebuild.
+        expect(find.byType(InputData), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      },
+    );
   });
 }


### PR DESCRIPTION
## What
`UsersDropdown.build` allocated a **new `SearchController()` on every build** and passed it to `InputData`:

```dart
Widget build(BuildContext context) {
  SearchController searchController = SearchController(); // new every build, never disposed
  ...
  child: InputData(searchController: searchController, ...),
}
```

`InputData` only reads `widget.searchController` **once in `initState`**, and it only disposes a controller when it created that controller itself (i.e. when the passed one is `null`, see `input_data.dart:712/754`). So:
- the first build's controller is attached but **never disposed** by anyone → leak;
- every subsequent rebuild allocates **another** controller that `InputData` ignores → wasted allocations.

## Fix
`UsersDropdown` never uses the controller for anything else, so stop creating and passing one. `InputData` already falls back to creating **and disposing** its own `SearchController` when none is supplied, so behavior is unchanged while the leak and the per-build allocation are eliminated.

## Tests
Adds a rebuild-stability case to `users_dropdown_test.dart` asserting the dropdown keeps rendering (and throws nothing) across multiple rebuilds.

## Validation
- `flutter analyze` — no issues.
- `flutter test` — **379 passing** (was 378; +1 new).
