### PR TITLE
perf: only synthesize LogsList fallback id when actions are present

### DIFF
--- a/lib/component/logs_list.dart
+++ b/lib/component/logs_list.dart
@@ -151,10 +151,14 @@ class LogsList extends StatelessWidget {
       } else {
         textFormatted.add(TextSpan(text: text));
       }
-      dynamic id = item.id ?? Utils.createCryptoRandomString(8);
       List<PopupMenuEntry<String>> buttons = [];
       Widget? actionsWidgets;
       if (actions != null) {
+        // Only synthesize a fallback id when actions exist, since it is used
+        // solely as the argument passed to an action's onTap. Computing it for
+        // every entry on every build ran a secure RNG needlessly when the list
+        // had no actions (the common case).
+        dynamic id = item.id ?? Utils.createCryptoRandomString(8);
         for (ButtonOptions option in actions!) {
           buttons.add(
             PopupMenuItem<String>(

--- a/test/component/logs_list_test.dart
+++ b/test/component/logs_list_test.dart
@@ -1,4 +1,5 @@
 import 'package:fabric_flutter/component/logs_list.dart';
+import 'package:fabric_flutter/helper/options.dart';
 import 'package:fabric_flutter/serialized/logs_data.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -91,6 +92,36 @@ void main() {
 
       // Assert
       expect(find.text(expected), findsOneWidget);
+    });
+
+    testWidgets('passes a non-null id to an action when the entry has none', (
+      tester,
+    ) async {
+      // Arrange: an entry without an id, so LogsList must synthesize one.
+      dynamic tappedId;
+      final logs = [
+        LogsData(text: 'A log line', timestamp: DateTime(2024, 1, 3, 9)),
+      ];
+      final actions = [
+        ButtonOptions(label: 'Remove', onTap: (dynamic id) => tappedId = id),
+      ];
+
+      // Act: open the popup menu and tap the action.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: LogsList(logs: logs, actions: actions),
+          ),
+        ),
+      );
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Remove'));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(tappedId, isNotNull);
+      expect(tappedId, isA<String>());
     });
   });
 }


### PR DESCRIPTION
## What
`LogsList.getItem` synthesized a random id for **every log entry on every build**:

```dart
dynamic id = item.id ?? Utils.createCryptoRandomString(8); // secure RNG per entry, every build
...
if (actions != null) {
  for (final option in actions!) {
    buttons.add(PopupMenuItem(onTap: () => option.onTap!(id), ...));
  }
}
```

`id` is used **only** as the argument passed to an action's `onTap`. So when a logs list has no actions — the common case — `Utils.createCryptoRandomString(8)` (a secure RNG) ran once per entry on every rebuild to produce a value that was immediately discarded.

## Fix
Move the fallback-id computation **inside** the `if (actions != null)` block so it runs only when an entry actually renders actions. Behavior is unchanged: entries with actions still receive `item.id`, or a generated id when the entry has none.

## Tests
Adds a `logs_list_test.dart` case that renders an entry without an id, opens its action menu, and asserts the action's `onTap` still receives a non-null `String` id.

## Validation
- `flutter analyze` — no issues.
- `flutter test` — **380 passing** (was 379; +1 new).
