### PR TITLE
ci: cover stacked PRs and move actions/checkout off the Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'ernysans-**'
 
 jobs:
   build:
@@ -17,7 +18,7 @@ jobs:
       id-token: 'write'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2


### PR DESCRIPTION
CI-infrastructure only. No changes under `lib/` or `test/`. Two independent CI-hygiene fixes, both in `.github/workflows/ci.yml`, total diff of 3 lines.

## 1. Stacked PRs were getting zero CI

`pull_request.branches` filters on the **base** branch, so a PR whose base is anything other than `main` never triggered the workflow at all.

This was not theoretical. In the recently merged four-PR stack, #222, #224 and #225 each sat with a completely empty `statusCheckRollup` for their entire life while stacked, and only ever got a real CI run after being retargeted to `main` immediately before merge. Three of the four PRs in that stack were effectively unverified for most of their existence.

```diff
   pull_request:
     branches:
       - main
+      - 'ernysans-**'
```

I kept an explicit `branches` filter rather than dropping it entirely. Dropping it would also have worked, but an explicit allow-list keeps the trigger surface intentional and matches the branch-naming convention this repo actually uses for stacked work, so a stray branch from elsewhere can't spend Actions minutes.

The `push` trigger is deliberately left as `[main]`. Widening it would make every push to a feature branch run twice — once for `push`, once for `pull_request`.

## 2. `actions/checkout` was on the deprecated Node 20 runtime

GitHub is retiring the Node 20 Actions runtime. Actions still built on it emit a deprecation annotation today and will hard-fail once the runtime is dropped.

Every version below was verified against the GitHub API (`gh api repos/<owner>/<repo>/releases/latest` plus the action's own `runs.using` at the relevant ref) — nothing here is guessed.

### Bumped

| Action | Before | Runtime before | After | Runtime after |
|---|---|---|---|---|
| `actions/checkout` | `v4` | `node20` (deprecated) | `v7` | `node24` |

`node24` first landed in `checkout@v5`. I pinned to `v7`, the current latest major (`v7.0.1`), rather than the minimum `v5`, so this doesn't need revisiting shortly. The only behavioural change across v5→v7 that could bite is v7 blocking fork-PR checkout under `pull_request_target` / `workflow_run`; this workflow uses neither trigger, so it does not apply. Pinned to the major tag, matching the existing style in the file.

### Deliberately NOT bumped

| Action | Version | Why |
|---|---|---|
| `subosito/flutter-action` | `v2` | **Not affected by the Node 20 deprecation.** Its `runs.using` is `composite`, not a Node runtime, so there is nothing to migrate. `v2` currently resolves to `v2.23.0` (`1a44944`), which is the latest release — there is no v3. Its only nested Node action is `actions/cache@v5`, already on `node24`. Bumping it would be a no-op at best, so it is left alone.

## Validation

- `.github/workflows/ci.yml` parses cleanly (`yaml.safe_load`); post-change triggers resolve to `push: {branches: [main]}` / `pull_request: {branches: [main, 'ernysans-**']}`.
- `flutter analyze` — **No issues found!** (0 issues)
- `flutter test` — **791 tests, all passed** (absolute total, unchanged by this PR since no Dart source was touched)